### PR TITLE
Add version checking CI/CD workflow

### DIFF
--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -2,8 +2,6 @@ name: Compare the package version of the PR with the main branch
 
 # The workflow gets triggered by pushes and pull requests
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -41,20 +41,20 @@ jobs:
               exit 0  # at least one version counters has been updated
             else
               echo -e "${RED}ERROR: Patch version is behind main. Update the version in setup.py"
-              echo -e "main -> $main_version"
-              echo -e "pr -> $pr_version"
+              echo -e "${RED}main -> $main_version"
+              echo -e "${RED}pr -> $pr_version"
               exit 1
             fi
           else
             echo -e "${RED}ERROR: Minor version is behind main. Update the version in setup.py"
-            echo -e "main -> $main_version"
-            echo -e "pr -> $pr_version"
+            echo -e "${RED}main -> $main_version"
+            echo -e "${RED}pr -> $pr_version"
             exit 1
           fi
         else
             echo -e "${RED}ERROR: Major version is behind main. Update the version in setup.py"
-            echo -e "main -> $main_version"
-            echo -e "pr -> $pr_version"
+            echo -e "${RED}main -> $main_version"
+            echo -e "${RED}pr -> $pr_version"
             exit 1
         fi
 

--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -1,0 +1,53 @@
+name: Compare the package version of the PR with the main branch
+
+# The workflow gets triggered by pushes and pull requests
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  compare-versions:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    # Checks out the code in the repository
+    - uses: actions/checkout@v3
+    - name: Compile CLUEstering modules
+      working-directory: ${{github.workspace}}
+      run: |
+        RED="\033[0;31m"
+
+        pr_version=$(cat setup.py | grep "__version__ " | awk -F '"' '{print $2}')
+        pr_major=$(echo "$pr_version" | awk -F '.' '{print $1}')
+        pr_minor=$(echo "$pr_version" | awk -F '.' '{print $2}')
+        pr_patch=$(echo "$pr_version" | awk -F '.' '{print $3}')
+
+        echo "Switching to 'main' branch"
+        git switch main
+        main_version=$(cat setup.py | grep "__version__ " | awk -F '"' '{print $2}')
+        main_major=$(echo "$main_version" | awk -F '.' '{print $1}')
+        main_minor=$(echo "$main_version" | awk -F '.' '{print $2}')
+        main_patch=$(echo "$main_version" | awk -F '.' '{print $3}')
+
+        if [ "$main_major" -le "$pr_major" ]; then
+          if [ "$main_minor" -le "$pr_minor" ]; then
+            if [ "$main_patch" -le "$pr_patch" ]; then
+              exit 0	# all the three version counters are unchanged or increased
+            else
+              echo -e "${RED}ERROR: Patch version is behind main. Update the version in setup.py"
+              exit 1
+            fi
+          else
+            echo -e "${RED}ERROR: Minor version is behind main. Update the version in setup.py"
+            exit 1
+          fi
+        else
+            echo -e "${RED}ERROR: Major version is behind main. Update the version in setup.py"
+            exit 1
+        fi
+

--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -41,14 +41,20 @@ jobs:
               exit 0  # at least one version counters has been updated
             else
               echo -e "${RED}ERROR: Patch version is behind main. Update the version in setup.py"
+              echo -e "main -> $main_version"
+              echo -e "pr -> $pr_version"
               exit 1
             fi
           else
             echo -e "${RED}ERROR: Minor version is behind main. Update the version in setup.py"
+            echo -e "main -> $main_version"
+            echo -e "pr -> $pr_version"
             exit 1
           fi
         else
             echo -e "${RED}ERROR: Major version is behind main. Update the version in setup.py"
+            echo -e "main -> $main_version"
+            echo -e "pr -> $pr_version"
             exit 1
         fi
 

--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Compile CLUEstering modules
       working-directory: ${{github.workspace}}
       run: |
+        git fetch
         RED="\033[0;31m"
 
         pr_version=$(cat setup.py | grep "__version__ " | awk -F '"' '{print $2}')

--- a/.github/workflows/check_package_version.yml
+++ b/.github/workflows/check_package_version.yml
@@ -36,8 +36,10 @@ jobs:
 
         if [ "$main_major" -le "$pr_major" ]; then
           if [ "$main_minor" -le "$pr_minor" ]; then
-            if [ "$main_patch" -le "$pr_patch" ]; then
-              exit 0	# all the three version counters are unchanged or increased
+            if [ "$main_patch" -lt "$pr_patch" ] ||
+               [ "$main_major" -lt "$pr_major" ] ||
+               [  "$main_minor" -lt "$pr_minor" ]; then
+              exit 0  # at least one version counters has been updated
             else
               echo -e "${RED}ERROR: Patch version is behind main. Update the version in setup.py"
               exit 1


### PR DESCRIPTION
This PR implements a workflow which checks whether the version in `setup.py` was updated.
The workflow fails if the versions in the PR is equal or behind the version in the main branch.
It's only run on pull requests, not on the main branch.