### PR TITLE
Import `OneToManyAssoc` from cms alpakatools

### DIFF
--- a/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
+++ b/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
@@ -1,0 +1,68 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_AtomicPairCounter_h
+#define HeterogeneousCore_AlpakaInterface_interface_AtomicPairCounter_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+namespace cms::alpakatools {
+
+  class AtomicPairCounter {
+  public:
+    using DoubleWord = uint64_t;
+
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter() : counter_{0} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(uint32_t first, uint32_t second) : counter_{pack(first, second)} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(DoubleWord values) : counter_{values} {}
+
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter& operator=(DoubleWord values) {
+      counter_.as_doubleword = values;
+      return *this;
+    }
+
+    struct Counters {
+      uint32_t first;   // in a "One to Many" association is the number of "One"
+      uint32_t second;  // in a "One to Many" association is the total number of associations
+    };
+
+    ALPAKA_FN_HOST_ACC constexpr Counters get() const { return counter_.as_counters; }
+
+    // atomically add as_counters, and return the previous value
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Counters add(const TAcc& acc, Counters c) {
+      Packer value{pack(c.first, c.second)};
+      Packer ret{0};
+      ret.as_doubleword =
+          alpaka::atomicAdd(acc, &counter_.as_doubleword, value.as_doubleword, alpaka::hierarchy::Blocks{});
+      return ret.as_counters;
+    }
+
+    // atomically increment first and add i to second, and return the previous value
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters constexpr inc_add(const TAcc& acc, uint32_t i) {
+      return add(acc, {1u, i});
+    }
+
+  private:
+    union Packer {
+      DoubleWord as_doubleword;
+      Counters as_counters;
+      constexpr Packer(DoubleWord _as_doubleword) : as_doubleword(_as_doubleword) { ; };
+      constexpr Packer(Counters _as_counters) : as_counters(_as_counters) { ; };
+    };
+
+    // pack two uint32_t values in a DoubleWord (aka uint64_t)
+    // this is needed because in c++17 a union can only be aggregate-initialised to its first type
+    // it can be probably removed with c++20, and replace with a designated initialiser
+    static constexpr DoubleWord pack(uint32_t first, uint32_t second) {
+      Packer ret{0};
+      ret.as_counters = {first, second};
+      return ret.as_doubleword;
+    }
+
+    Packer counter_;
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_AtomicPairCounter_h

--- a/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
+++ b/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_AlpakaInterface_interface_AtomicPairCounter_h
-#define HeterogeneousCore_AlpakaInterface_interface_AtomicPairCounter_h
+#ifndef AtomicPairCounter_h
+#define AtomicPairCounter_h
 
 #include <cstdint>
 

--- a/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
+++ b/CLUEstering/alpaka/AlpakaCore/AtomicPairCounter.h
@@ -12,8 +12,10 @@ namespace cms::alpakatools {
     using DoubleWord = uint64_t;
 
     ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter() : counter_{0} {}
-    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(uint32_t first, uint32_t second) : counter_{pack(first, second)} {}
-    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(DoubleWord values) : counter_{values} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(uint32_t first, uint32_t second)
+        : counter_{pack(first, second)} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(DoubleWord values)
+        : counter_{values} {}
 
     ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter& operator=(DoubleWord values) {
       counter_.as_doubleword = values;
@@ -21,8 +23,9 @@ namespace cms::alpakatools {
     }
 
     struct Counters {
-      uint32_t first;   // in a "One to Many" association is the number of "One"
-      uint32_t second;  // in a "One to Many" association is the total number of associations
+      uint32_t first;  // in a "One to Many" association is the number of "One"
+      uint32_t
+          second;  // in a "One to Many" association is the total number of associations
     };
 
     ALPAKA_FN_HOST_ACC constexpr Counters get() const { return counter_.as_counters; }
@@ -32,14 +35,15 @@ namespace cms::alpakatools {
     ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Counters add(const TAcc& acc, Counters c) {
       Packer value{pack(c.first, c.second)};
       Packer ret{0};
-      ret.as_doubleword =
-          alpaka::atomicAdd(acc, &counter_.as_doubleword, value.as_doubleword, alpaka::hierarchy::Blocks{});
+      ret.as_doubleword = alpaka::atomicAdd(
+          acc, &counter_.as_doubleword, value.as_doubleword, alpaka::hierarchy::Blocks{});
       return ret.as_counters;
     }
 
     // atomically increment first and add i to second, and return the previous value
     template <typename TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters constexpr inc_add(const TAcc& acc, uint32_t i) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters constexpr inc_add(const TAcc& acc,
+                                                              uint32_t i) {
       return add(acc, {1u, i});
     }
 

--- a/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
+++ b/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
@@ -1,0 +1,55 @@
+#ifndef FWCore_Utilities_interface_CMSUnrollLoop_h
+#define FWCore_Utilities_interface_CMSUnrollLoop_h
+
+#include "FWCore/Utilities/interface/stringize.h"
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+// CUDA or HIP device compiler
+
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll N))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(unroll 1))
+
+#define CMS_DEVICE_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll N))
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(unroll 1))
+
+#else  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+// any host compiler
+#define CMS_DEVICE_UNROLL_LOOP
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N)
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE
+
+#if defined(__clang__)
+// clang host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(clang loop unroll(enable)))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(clang loop unroll_count(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(clang loop unroll(disable)))
+
+#elif defined(__INTEL_COMPILER)
+// Intel icc compiler
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(nounroll))
+
+#elif defined(__GNUC__)
+// GCC host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(GCC ivdep))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(GCC unroll N)) _Pragma(EDM_STRINGIZE(GCC ivdep))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(GCC unroll 1))
+
+#else
+// unsupported or unknown compiler
+
+#define CMS_UNROLL_LOOP
+#define CMS_UNROLL_LOOP_COUNT(N)
+#define CMS_UNROLL_LOOP_DISABLE
+
+#endif  // defined(__clang__) || defined(__GNUC__) || ...
+
+#endif  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+#endif  // FWCore_Utilities_interface_CMSUnrollLoop_h

--- a/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
+++ b/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
@@ -1,7 +1,7 @@
-#ifndef FWCore_Utilities_interface_CMSUnrollLoop_h
-#define FWCore_Utilities_interface_CMSUnrollLoop_h
+#ifndef CMSUnrollLoop_h
+#define CMsUnrollLoop_h
 
-#include "FWCore/Utilities/interface/stringize.h"
+#include "stringize.h"
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 // CUDA or HIP device compiler

--- a/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
+++ b/CLUEstering/alpaka/AlpakaCore/CMSUnrollLoop.h
@@ -38,7 +38,8 @@
 // GCC host compiler
 
 #define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(GCC ivdep))
-#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(GCC unroll N)) _Pragma(EDM_STRINGIZE(GCC ivdep))
+#define CMS_UNROLL_LOOP_COUNT(N) \
+  _Pragma(EDM_STRINGIZE(GCC unroll N)) _Pragma(EDM_STRINGIZE(GCC ivdep))
 #define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(GCC unroll 1))
 
 #else

--- a/CLUEstering/alpaka/AlpakaCore/FlexiStorage.h
+++ b/CLUEstering/alpaka/AlpakaCore/FlexiStorage.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_AlpakaInterface_interface_FlexiStorage_h
-#define HeterogeneousCore_AlpakaInterface_interface_FlexiStorage_h
+#ifndef FlexiStorage_h
+#define FlexiStorage_h
 
 #include <cstdint>
 

--- a/CLUEstering/alpaka/AlpakaCore/FlexiStorage.h
+++ b/CLUEstering/alpaka/AlpakaCore/FlexiStorage.h
@@ -1,0 +1,46 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_FlexiStorage_h
+#define HeterogeneousCore_AlpakaInterface_interface_FlexiStorage_h
+
+#include <cstdint>
+
+namespace cms::alpakatools {
+
+  template <typename I, int S>
+  class FlexiStorage {
+  public:
+    constexpr int capacity() const { return S; }
+
+    constexpr I& operator[](int i) { return m_v[i]; }
+    constexpr const I& operator[](int i) const { return m_v[i]; }
+
+    constexpr I* data() { return m_v; }
+    constexpr I const* data() const { return m_v; }
+
+  private:
+    I m_v[S];
+  };
+
+  template <typename I>
+  class FlexiStorage<I, -1> {
+  public:
+    constexpr void init(I* v, int s) {
+      m_v = v;
+      m_capacity = s;
+    }
+
+    constexpr int capacity() const { return m_capacity; }
+
+    constexpr I& operator[](int i) { return m_v[i]; }
+    constexpr const I& operator[](int i) const { return m_v[i]; }
+
+    constexpr I* data() { return m_v; }
+    constexpr I const* data() const { return m_v; }
+
+  private:
+    I* m_v;
+    int m_capacity;
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_FlexiStorage_h

--- a/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
+++ b/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
@@ -15,11 +15,9 @@
 
 namespace cms::alpakatools {
 
-  template <
-      typename I,  // type stored in the container (usually an index in a vector of the input values)
-      int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
-      int32_t SIZE  // max number of element. If -1 is initialized at runtime using external storage
-      >
+  template <typename I,    // type stored in the container
+            int32_t ONES,  // number of "Ones" +1. If -1 is initialized at runtime
+            int32_t SIZE>  // max number of element. If -1 is initialized at runtime
   class OneToManyAssocBase {
   public:
     using Counter = uint32_t;
@@ -163,11 +161,9 @@ namespace cms::alpakatools {
     int32_t psws;  // prefix-scan working space
   };
 
-  template <
-      typename I,  // type stored in the container (usually an index in a vector of the input values)
-      int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
-      int32_t SIZE  // max number of element. If -1 is initialized at runtime using external storage
-      >
+  template <typename I,    // type stored in the container
+            int32_t ONES,  // number of "Ones" +1. If -1 is initialized at runtime
+            int32_t SIZE>  // max number of element. If -1 is initialized at runtime
   class OneToManyAssocSequential : public OneToManyAssocBase<I, ONES, SIZE> {
   public:
     using index_type = typename OneToManyAssocBase<I, ONES, SIZE>::index_type;
@@ -214,11 +210,9 @@ namespace cms::alpakatools {
     };
   };
 
-  template <
-      typename I,  // type stored in the container (usually an index in a vector of the input values)
-      int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
-      int32_t SIZE  // max number of element. If -1 is initialized at runtime using external storage
-      >
+  template <typename I,    // type stored in the container
+            int32_t ONES,  // number of "Ones" +1. If -1 is initialized at runtime
+            int32_t SIZE>  // max number of element. If -1 is initialized at runtime
   class OneToManyAssocRandomAccess : public OneToManyAssocBase<I, ONES, SIZE> {
   public:
     using Counter = typename OneToManyAssocBase<I, ONES, SIZE>::Counter;

--- a/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
+++ b/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
@@ -1,0 +1,269 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_OneToManyAssoc_h
+#define HeterogeneousCore_AlpakaInterface_interface_OneToManyAssoc_h
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "AtomicPairCounter.h"
+#include "FlexiStorage.h"
+#include "prefixScan.h"
+#include "alpakaWorkDiv.h"
+
+namespace cms::alpakatools {
+
+  template <typename I,    // type stored in the container (usually an index in a vector of the input values)
+            int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
+            int32_t SIZE   // max number of element. If -1 is initialized at runtime using external storage
+            >
+  class OneToManyAssocBase {
+  public:
+    using Counter = uint32_t;
+
+    using CountersOnly = OneToManyAssocBase<I, ONES, 0>;
+
+    using index_type = I;
+
+    struct View {
+      OneToManyAssocBase *assoc = nullptr;
+      Counter *offStorage = nullptr;
+      index_type *contentStorage = nullptr;
+      int32_t offSize = -1;
+      int32_t contentSize = -1;
+    };
+
+    static constexpr int32_t ctNOnes() { return ONES; }
+    constexpr auto totOnes() const { return off.capacity(); }
+    constexpr auto nOnes() const { return totOnes() - 1; }
+    static constexpr int32_t ctCapacity() { return SIZE; }
+    constexpr auto capacity() const { return content.capacity(); }
+
+    ALPAKA_FN_HOST_ACC void initStorage(View view) {
+      ALPAKA_ASSERT_ACC(view.assoc == this);
+      if constexpr (ctCapacity() < 0) {
+        ALPAKA_ASSERT_ACC(view.contentStorage);
+        ALPAKA_ASSERT_ACC(view.contentSize > 0);
+        content.init(view.contentStorage, view.contentSize);
+      }
+      if constexpr (ctNOnes() < 0) {
+        ALPAKA_ASSERT_ACC(view.offStorage);
+        ALPAKA_ASSERT_ACC(view.offSize > 0);
+        off.init(view.offStorage, view.offSize);
+      }
+    }
+
+    ALPAKA_FN_HOST_ACC void zero() {
+      for (int32_t i = 0; i < totOnes(); ++i) {
+        off[i] = 0;
+      }
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void add(const TAcc &acc, CountersOnly const &co) {
+      for (uint32_t i = 0; static_cast<int>(i) < totOnes(); ++i) {
+        alpaka::atomicAdd(acc, off.data() + i, co.off[i], alpaka::hierarchy::Blocks{});
+      }
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE static uint32_t atomicIncrement(const TAcc &acc, Counter &x) {
+      return alpaka::atomicAdd(acc, &x, 1u, alpaka::hierarchy::Blocks{});
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE static uint32_t atomicDecrement(const TAcc &acc, Counter &x) {
+      return alpaka::atomicSub(acc, &x, 1u, alpaka::hierarchy::Blocks{});
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const TAcc &acc, I b) {
+      ALPAKA_ASSERT_ACC(b < static_cast<uint32_t>(nOnes()));
+      atomicIncrement(acc, off[b]);
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const TAcc &acc, I b, index_type j) {
+      ALPAKA_ASSERT_ACC(b < static_cast<uint32_t>(nOnes()));
+      auto w = atomicDecrement(acc, off[b]);
+      ALPAKA_ASSERT_ACC(w > 0);
+      content[w - 1] = j;
+    }
+
+    // this MUST BE DONE in a single block (or in two kernels!)
+    struct zeroAndInit {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc &acc, View view) const {
+        ALPAKA_ASSERT_ACC((1 == alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0]));
+        ALPAKA_ASSERT_ACC((0 == alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0]));
+        auto h = view.assoc;
+        if (cms::alpakatools::once_per_block(acc)) {
+          h->psws = 0;
+          h->initStorage(view);
+        }
+        alpaka::syncBlockThreads(acc);
+        for (int i : cms::alpakatools::independent_group_elements(acc, h->totOnes())) {
+          h->off[i] = 0;
+        }
+      }
+    };
+
+    template <typename TAcc, typename TQueue>
+    ALPAKA_FN_INLINE static void launchZero(OneToManyAssocBase *h, TQueue &queue) {
+      View view = {h, nullptr, nullptr, -1, -1};
+      launchZero<TAcc>(view, queue);
+    }
+
+    template <typename TAcc, typename TQueue>
+    ALPAKA_FN_INLINE static void launchZero(View view, TQueue &queue) {
+      if constexpr (ctCapacity() < 0) {
+        ALPAKA_ASSERT_ACC(view.contentStorage);
+        ALPAKA_ASSERT_ACC(view.contentSize > 0);
+      }
+      if constexpr (ctNOnes() < 0) {
+        ALPAKA_ASSERT_ACC(view.offStorage);
+        ALPAKA_ASSERT_ACC(view.offSize > 0);
+      }
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        auto nthreads = 1024;
+        auto nblocks = 1;  // MUST BE ONE as memory is initialize in thread 0 (alternative is two kernels);
+        auto workDiv = cms::alpakatools::make_workdiv<TAcc>(nblocks, nthreads);
+        alpaka::exec<TAcc>(queue, workDiv, zeroAndInit{}, view);
+      } else {
+        auto h = view.assoc;
+        ALPAKA_ASSERT_ACC(h);
+        h->initStorage(view);
+        h->zero();
+        h->psws = 0;
+      }
+    }
+
+    constexpr auto size() const { return uint32_t(off[totOnes() - 1]); }
+    constexpr auto size(uint32_t b) const { return off[b + 1] - off[b]; }
+
+    constexpr index_type const *begin() const { return content.data(); }
+    constexpr index_type const *end() const { return begin() + size(); }
+
+    constexpr index_type const *begin(uint32_t b) const { return content.data() + off[b]; }
+    constexpr index_type const *end(uint32_t b) const { return content.data() + off[b + 1]; }
+
+    FlexiStorage<Counter, ONES> off;
+    FlexiStorage<index_type, SIZE> content;
+    int32_t psws;  // prefix-scan working space
+  };
+
+  template <typename I,    // type stored in the container (usually an index in a vector of the input values)
+            int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
+            int32_t SIZE   // max number of element. If -1 is initialized at runtime using external storage
+            >
+  class OneToManyAssocSequential : public OneToManyAssocBase<I, ONES, SIZE> {
+  public:
+    using index_type = typename OneToManyAssocBase<I, ONES, SIZE>::index_type;
+
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE int32_t
+    bulkFill(const TAcc &acc, AtomicPairCounter &apc, index_type const *v, uint32_t n) {
+      auto c = apc.inc_add(acc, n);
+      if (int(c.first) >= this->nOnes())
+        return -int32_t(c.first);
+      this->off[c.first] = c.second;
+      for (uint32_t j = 0; j < n; ++j)
+        this->content[c.second + j] = v[j];
+      return c.first;
+    }
+
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void bulkFinalize(AtomicPairCounter const &apc) {
+      this->off[apc.get().first] = apc.get().second;
+    }
+
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void bulkFinalizeFill(TAcc &acc, AtomicPairCounter const &apc) {
+      int f = apc.get().first;
+      auto s = apc.get().second;
+      if (f >= this->nOnes()) {  // overflow!
+        this->off[this->nOnes()] = uint32_t(this->off[this->nOnes() - 1]);
+        return;
+      }
+      auto first = f + alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
+      for (int i = first; i < this->totOnes(); i += alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0]) {
+        this->off[i] = s;
+      }
+    }
+
+    struct finalizeBulk {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc &acc,
+                                    AtomicPairCounter const *apc,
+                                    OneToManyAssocSequential *__restrict__ assoc) const {
+        assoc->bulkFinalizeFill(acc, *apc);
+      }
+    };
+  };
+
+  template <typename I,    // type stored in the container (usually an index in a vector of the input values)
+            int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
+            int32_t SIZE   // max number of element. If -1 is initialized at runtime using external storage
+            >
+  class OneToManyAssocRandomAccess : public OneToManyAssocBase<I, ONES, SIZE> {
+  public:
+    using Counter = typename OneToManyAssocBase<I, ONES, SIZE>::Counter;
+    using View = typename OneToManyAssocBase<I, ONES, SIZE>::View;
+
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void finalize(TAcc &acc, Counter *ws = nullptr) {
+      ALPAKA_ASSERT_ACC(this->off[this->totOnes() - 1] == 0);
+      blockPrefixScan(acc, this->off.data(), this->totOnes(), ws);
+      ALPAKA_ASSERT_ACC(this->off[this->totOnes() - 1] == this->off[this->totOnes() - 2]);
+    }
+
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void finalize() {
+      // Single thread finalize.
+      for (uint32_t i = 1; static_cast<int>(i) < this->totOnes(); ++i)
+        this->off[i] += this->off[i - 1];
+    }
+
+    template <typename TAcc, typename TQueue>
+    ALPAKA_FN_INLINE static void launchFinalize(OneToManyAssocRandomAccess *h, TQueue &queue) {
+      View view = {h, nullptr, nullptr, -1, -1};
+      launchFinalize<TAcc>(view, queue);
+    }
+
+    template <typename TAcc, typename TQueue>
+    ALPAKA_FN_INLINE static void launchFinalize(View view, TQueue &queue) {
+      // View stores a base pointer, we need to upcast back...
+      auto h = static_cast<OneToManyAssocRandomAccess *>(view.assoc);
+      ALPAKA_ASSERT_ACC(h);
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        Counter *poff = (Counter *)((char *)(h) + offsetof(OneToManyAssocRandomAccess, off));
+        auto nOnes = OneToManyAssocRandomAccess::ctNOnes();
+        if constexpr (OneToManyAssocRandomAccess::ctNOnes() < 0) {
+          ALPAKA_ASSERT_ACC(view.offStorage);
+          ALPAKA_ASSERT_ACC(view.offSize > 0);
+          nOnes = view.offSize;
+          poff = view.offStorage;
+        }
+        ALPAKA_ASSERT_ACC(nOnes > 0);
+        int32_t *ppsws = (int32_t *)((char *)(h) + offsetof(OneToManyAssocRandomAccess, psws));
+        auto nthreads = 1024;
+        auto nblocks = (nOnes + nthreads - 1) / nthreads;
+        auto workDiv = cms::alpakatools::make_workdiv<TAcc>(nblocks, nthreads);
+        alpaka::exec<TAcc>(queue,
+                           workDiv,
+                           multiBlockPrefixScan<Counter>(),
+                           poff,
+                           poff,
+                           nOnes,
+                           nblocks,
+                           ppsws,
+                           alpaka::getPreferredWarpSize(alpaka::getDev(queue)));
+      } else {
+        h->finalize();
+      }
+    }
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_CUDAUtilities_interface_HistoContainer_h

--- a/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
+++ b/CLUEstering/alpaka/AlpakaCore/OneToManyAssoc.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_AlpakaInterface_interface_OneToManyAssoc_h
-#define HeterogeneousCore_AlpakaInterface_interface_OneToManyAssoc_h
+#ifndef OneToManyAssoc_h
+#define OneToManyAssoc_h
 
 #include <algorithm>
 #include <cstddef>

--- a/CLUEstering/alpaka/AlpakaCore/prefixScan.h
+++ b/CLUEstering/alpaka/AlpakaCore/prefixScan.h
@@ -1,0 +1,239 @@
+#ifndef prefixScan_h
+#define prefixScan_h
+
+#include <alpaka/alpaka.hpp>
+
+#include "CMSUnrollLoop.h"
+#include "alpakaConfig.h"
+#include "alpakaWorkDiv.h"
+namespace cms::alpakatools {
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  constexpr bool isPowerOf2(T v) {
+    // returns true iif v has only one bit set.
+    while (v) {
+      if (v & 1)
+        return !(v >> 1);
+      else
+        v >>= 1;
+    }
+    return false;
+  }
+
+  template <typename TAcc, typename T, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void warpPrefixScan(
+      const TAcc& acc, int32_t laneId, T const* ci, T* co, uint32_t i, bool active = true) {
+    // ci and co may be the same
+    T x = active ? ci[i] : 0;
+    CMS_UNROLL_LOOP
+    for (int32_t offset = 1; offset < alpaka::warp::getSize(acc); offset <<= 1) {
+      // Force the exact type for integer types otherwise the compiler will find the template resolution ambiguous.
+      using dataType = std::conditional_t<std::is_floating_point_v<T>, T, std::int32_t>;
+      T y = alpaka::warp::shfl(acc, static_cast<dataType>(x), laneId - offset);
+      if (laneId >= offset)
+        x += y;
+    }
+    if (active)
+      co[i] = x;
+  }
+
+  template <typename TAcc, typename T, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void warpPrefixScan(
+      const TAcc& acc, int32_t laneId, T* c, uint32_t i, bool active = true) {
+    warpPrefixScan(acc, laneId, c, c, i, active);
+  }
+
+  // limited to warpSize² elements
+  template <typename TAcc, typename T>
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void blockPrefixScan(
+      const TAcc& acc, T const* ci, T* co, int32_t size, T* ws = nullptr) {
+    if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+      const auto warpSize = alpaka::warp::getSize(acc);
+      int32_t const blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      int32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      ALPAKA_ASSERT_ACC(ws);
+      ALPAKA_ASSERT_ACC(size <= warpSize * warpSize);
+      ALPAKA_ASSERT_ACC(0 == blockDimension % warpSize);
+      auto first = blockThreadIdx;
+      ALPAKA_ASSERT_ACC(isPowerOf2(warpSize));
+      auto laneId = blockThreadIdx & (warpSize - 1);
+      auto warpUpRoundedSize = (size + warpSize - 1) / warpSize * warpSize;
+
+      for (auto i = first; i < warpUpRoundedSize; i += blockDimension) {
+        // When padding the warp, warpPrefixScan is a noop
+        warpPrefixScan(acc, laneId, ci, co, i, i < size);
+        if (i < size) {
+          // Skipped in warp padding threads.
+          auto warpId = i / warpSize;
+          ALPAKA_ASSERT_ACC(warpId < warpSize);
+          if ((warpSize - 1) == laneId)
+            ws[warpId] = co[i];
+        }
+      }
+      alpaka::syncBlockThreads(acc);
+      if (size <= warpSize)
+        return;
+      if (blockThreadIdx < warpSize) {
+        warpPrefixScan(acc, laneId, ws, blockThreadIdx);
+      }
+      alpaka::syncBlockThreads(acc);
+      for (auto i = first + warpSize; i < size; i += blockDimension) {
+        int32_t warpId = i / warpSize;
+        co[i] += ws[warpId - 1];
+      }
+      alpaka::syncBlockThreads(acc);
+    } else {
+      co[0] = ci[0];
+      for (int32_t i = 1; i < size; ++i)
+        co[i] = ci[i] + co[i - 1];
+    }
+  }
+
+  template <typename TAcc, typename T>
+  ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void blockPrefixScan(const TAcc& acc,
+                                                           T* __restrict__ c,
+                                                           int32_t size,
+                                                           T* __restrict__ ws = nullptr) {
+    if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+      const auto warpSize = alpaka::warp::getSize(acc);
+      int32_t const blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      int32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      ALPAKA_ASSERT_ACC(ws);
+      ALPAKA_ASSERT_ACC(size <= warpSize * warpSize);
+      ALPAKA_ASSERT_ACC(0 == blockDimension % warpSize);
+      auto first = blockThreadIdx;
+      auto laneId = blockThreadIdx & (warpSize - 1);
+      auto warpUpRoundedSize = (size + warpSize - 1) / warpSize * warpSize;
+
+      for (auto i = first; i < warpUpRoundedSize; i += blockDimension) {
+        // When padding the warp, warpPrefixScan is a noop
+        warpPrefixScan(acc, laneId, c, i, i < size);
+        if (i < size) {
+          // Skipped in warp padding threads.
+          auto warpId = i / warpSize;
+          ALPAKA_ASSERT_ACC(warpId < warpSize);
+          if ((warpSize - 1) == laneId)
+            ws[warpId] = c[i];
+        }
+      }
+      alpaka::syncBlockThreads(acc);
+      if (size <= warpSize)
+        return;
+      if (blockThreadIdx < warpSize) {
+        warpPrefixScan(acc, laneId, ws, blockThreadIdx);
+      }
+      alpaka::syncBlockThreads(acc);
+      for (auto i = first + warpSize; i < size; i += blockDimension) {
+        auto warpId = i / warpSize;
+        c[i] += ws[warpId - 1];
+      }
+      alpaka::syncBlockThreads(acc);
+    } else {
+      for (int32_t i = 1; i < size; ++i)
+        c[i] += c[i - 1];
+    }
+  }
+
+  // in principle not limited....
+  template <typename T>
+  struct multiBlockPrefixScan {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        const TAcc& acc, T const* ci, T* co, uint32_t size, int32_t numBlocks, int32_t* pc, std::size_t warpSize) const {
+      // Get shared variable. The workspace is needed only for multi-threaded accelerators.
+      T* ws = nullptr;
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        ws = alpaka::getDynSharedMem<T>(acc);
+      }
+      ALPAKA_ASSERT_ACC(warpSize == static_cast<std::size_t>(alpaka::warp::getSize(acc)));
+      [[maybe_unused]] const auto elementsPerGrid = alpaka::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u];
+      const auto elementsPerBlock = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
+      const auto threadsPerBlock = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const auto blocksPerGrid = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+      const auto blockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+      const auto threadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
+      ALPAKA_ASSERT_ACC(elementsPerGrid >= size);
+      // first each block does a scan
+      [[maybe_unused]] int off = elementsPerBlock * blockIdx;
+      if (size - off > 0) {
+        blockPrefixScan(acc, ci + off, co + off, std::min(elementsPerBlock, size - off), ws);
+      }
+
+      // count blocks that finished
+      auto& isLastBlockDone = alpaka::declareSharedVar<bool, __COUNTER__>(acc);
+      //__shared__ bool isLastBlockDone;
+      if (0 == threadIdx) {
+        alpaka::mem_fence(acc, alpaka::memory_scope::Device{});
+        auto value = alpaka::atomicAdd(acc, pc, 1, alpaka::hierarchy::Blocks{});  // block counter
+        isLastBlockDone = (value == (int(blocksPerGrid) - 1));
+      }
+
+      alpaka::syncBlockThreads(acc);
+
+      if (!isLastBlockDone)
+        return;
+
+      ALPAKA_ASSERT_ACC(int(blocksPerGrid) == *pc);
+
+      // good each block has done its work and now we are left in last block
+
+      // let's get the partial sums from each block except the last, which receives 0.
+      T* psum = nullptr;
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        psum = ws + warpSize;
+      } else {
+        psum = alpaka::getDynSharedMem<T>(acc);
+      }
+      for (int32_t i = threadIdx, ni = blocksPerGrid; i < ni; i += threadsPerBlock) {
+        auto j = elementsPerBlock * i + elementsPerBlock - 1;
+        psum[i] = (j < size) ? co[j] : T(0);
+      }
+      alpaka::syncBlockThreads(acc);
+      blockPrefixScan(acc, psum, psum, blocksPerGrid, ws);
+
+      // now it would have been handy to have the other blocks around...
+      // Simplify the computation by having one version where threads per block = block size
+      // and a second for the one thread per block accelerator.
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        //  Here threadsPerBlock == elementsPerBlock
+        for (uint32_t i = threadIdx + threadsPerBlock, k = 0; i < size; i += threadsPerBlock, ++k) {
+          co[i] += psum[k];
+        }
+      } else {
+        // We are single threaded here, adding partial sums starting with the 2nd block.
+        for (uint32_t i = elementsPerBlock; i < size; i++) {
+          co[i] += psum[i / elementsPerBlock - 1];
+        }
+      }
+    }
+  };
+}  // namespace cms::alpakatools
+
+// declare the amount of block shared memory used by the multiBlockPrefixScan kernel
+namespace alpaka::trait {
+  // Variable size shared mem
+  template <typename TAcc, typename T>
+  struct BlockSharedMemDynSizeBytes<cms::alpakatools::multiBlockPrefixScan<T>, TAcc> {
+    template <typename TVec>
+    ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(
+        cms::alpakatools::multiBlockPrefixScan<T> const& /* kernel */,
+        TVec const& /* blockThreadExtent */,
+        TVec const& /* threadElemExtent */,
+        T const* /* ci */,
+        T const* /* co */,
+        int32_t /* size */,
+        int32_t numBlocks,
+        int32_t const* /* pc */,
+        // This trait function does not receive the accelerator object to look up the warp size
+        std::size_t warpSize) {
+      // We need workspace (T[warpsize]) + partial sums (T[numblocks]).
+      if constexpr (cms::alpakatools::requires_single_thread_per_block_v<TAcc>) {
+        return sizeof(T) * numBlocks;
+      } else {
+        return sizeof(T) * (warpSize + numBlocks);
+      }
+    }
+  };
+
+}  // namespace alpaka::trait
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_prefixScan_h

--- a/CLUEstering/alpaka/AlpakaCore/prefixScan.h
+++ b/CLUEstering/alpaka/AlpakaCore/prefixScan.h
@@ -6,6 +6,7 @@
 #include "CMSUnrollLoop.h"
 #include "alpakaConfig.h"
 #include "alpakaWorkDiv.h"
+
 namespace cms::alpakatools {
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
   constexpr bool isPowerOf2(T v) {

--- a/CLUEstering/alpaka/AlpakaCore/stringize.h
+++ b/CLUEstering/alpaka/AlpakaCore/stringize.h
@@ -1,0 +1,8 @@
+#ifndef FWCore_Utilities_interface_stringize_h
+#define FWCore_Utilities_interface_stringize_h
+
+// convert the macro argument to a null-terminated quoted string
+#define EDM_STRINGIZE_(token) #token
+#define EDM_STRINGIZE(token) EDM_STRINGIZE_(token)
+
+#endif  // FWCore_Utilities_interface_stringize_h

--- a/CLUEstering/alpaka/AlpakaCore/stringize.h
+++ b/CLUEstering/alpaka/AlpakaCore/stringize.h
@@ -1,5 +1,5 @@
-#ifndef FWCore_Utilities_interface_stringize_h
-#define FWCore_Utilities_interface_stringize_h
+#ifndef stringize_h
+#define stringize_h
 
 // convert the macro argument to a null-terminated quoted string
 #define EDM_STRINGIZE_(token) #token


### PR DESCRIPTION
This PR adds the following headers from cms alpakatools:
* `OneToManyAssoc`
* `prefixScan`
* `AtomicPairCounter`
* `CMSUnrollLoop`
* `FlexiStorage`
* `stringsize`
The "Assoc" class is needed for a more efficient rework of the tiles (the others are its dependencies)