### PR TITLE
Reduce D2H memcpys in release mode

### DIFF
--- a/CLUEstering/alpaka/CLUE/CLUEAlgoAlpaka.h
+++ b/CLUEstering/alpaka/CLUE/CLUEAlgoAlpaka.h
@@ -236,6 +236,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Wait for all the operations in the queue to finish
     alpaka::wait(queue_);
 
+#ifdef DEBUG
     alpaka::memcpy(queue_,
                    cms::alpakatools::make_host_view(h_points.m_rho.data(), h_points.n),
                    d_points.rho,
@@ -249,6 +250,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         cms::alpakatools::make_host_view(h_points.m_nearestHigher.data(), h_points.n),
         d_points.nearest_higher,
         static_cast<uint32_t>(h_points.n));
+#endif
     alpaka::memcpy(
         queue_,
         cms::alpakatools::make_host_view(h_points.m_clusterIndex.data(), h_points.n),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  add_compile_definitions(DEBUG)
   set(CMAKE_CXX_FLAGS "-Wall -Wextra -g -O0")
 elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release")
   set(CMAKE_CXX_FLAGS "-O2")


### PR DESCRIPTION
This PR removes the device to host memcpy of rho, delta and nearestHigher since they are not used from the Python API.
The memcpys are maintained when compiling in debug mode.