### PR TITLE
Add list of files to exclude in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+benchmark/ export-ignore
+data/ export-ignore
+docker/ export-ignore
+images/ export-ignore
+tests/ export-ignore
+packaging.sh export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Add a `.gitattributes` file containing a list of files and folders that don't need to be included in releases tarballs, so to reduce the resulting size.