### PR TITLE
Add `seed_dc` parameter and reorder `Clusterer` constructor arguments

### DIFF
--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -12,13 +12,14 @@ template <uint8_t Ndim, typename Kernel>
 void run(float dc,
          float rhoc,
          float dm,
+         float seed_dc,
          int pPBin,
          std::tuple<float*, int*>&& pData,
          uint32_t n_points,
          const Kernel& kernel,
          Queue queue,
          size_t block_size) {
-  clue::Clusterer<Ndim> algo(dc, rhoc, dm, pPBin, queue);
+  clue::Clusterer<Ndim> algo(dc, rhoc, dm, pPBin, queue, seed_dc);
 
   // Create the host and device points
   clue::PointsHost<Ndim> h_points(

--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -19,7 +19,7 @@ void run(float dc,
          const Kernel& kernel,
          Queue queue,
          size_t block_size) {
-  clue::Clusterer<Ndim> algo(dc, rhoc, dm, pPBin, queue, seed_dc);
+  clue::Clusterer<Ndim> algo(queue, dc, rhoc, dm, seed_dc, pPBin);
 
   // Create the host and device points
   clue::PointsHost<Ndim> h_points(

--- a/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
+++ b/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
@@ -30,6 +30,7 @@ namespace alpaka_cuda_async {
   void mainRun(float dc,
                float rhoc,
                float dm,
+               float seed_dc,
                int pPBin,
                py::array_t<float> data,
                py::array_t<int> results,
@@ -46,7 +47,7 @@ namespace alpaka_cuda_async {
     const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
 
     // Create the queue
-    Queue queue_(dev_acc);
+    Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {
@@ -54,110 +55,120 @@ namespace alpaka_cuda_async {
         run<1, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (2):
         run<2, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (3):
         run<3, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (4):
         run<4, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (5):
         run<5, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (6):
         run<6, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (7):
         run<7, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (8):
         run<8, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (9):
         run<9, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (10):
         run<10, Kernel>(dc,
                         rhoc,
                         dm,
+                        seed_dc,
                         pPBin,
                         std::make_tuple(pData, pResults),
                         n_points,
                         kernel,
-                        queue_,
+                        queue,
                         block_size);
         return;
       [[unlikely]] default:
@@ -173,6 +184,7 @@ namespace alpaka_cuda_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -186,6 +198,7 @@ namespace alpaka_cuda_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -197,6 +210,7 @@ namespace alpaka_cuda_async {
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
+                                  float,
                                   float,
                                   float,
                                   int,

--- a/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
+++ b/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
@@ -31,6 +31,7 @@ namespace alpaka_rocm_async {
   void mainRun(float dc,
                float rhoc,
                float dm,
+               float seed_dc,
                int pPBin,
                py::array_t<float> data,
                py::array_t<int> results,
@@ -47,7 +48,7 @@ namespace alpaka_rocm_async {
     const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
 
     // Create the queue
-    Queue queue_(dev_acc);
+    Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {
@@ -55,110 +56,120 @@ namespace alpaka_rocm_async {
         run<1, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (2):
         run<2, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (3):
         run<3, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (4):
         run<4, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (5):
         run<5, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (6):
         run<6, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (7):
         run<7, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (8):
         run<8, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (9):
         run<9, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (10):
         run<10, Kernel>(dc,
                         rhoc,
                         dm,
+                        seed_dc,
                         pPBin,
                         std::make_tuple(pData, pResults),
                         n_points,
                         kernel,
-                        queue_,
+                        queue,
                         block_size);
         return;
       [[unlikely]] default:
@@ -176,6 +187,7 @@ namespace alpaka_rocm_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -189,6 +201,7 @@ namespace alpaka_rocm_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -200,6 +213,7 @@ namespace alpaka_rocm_async {
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
+                                  float,
                                   float,
                                   float,
                                   int,

--- a/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
@@ -31,6 +31,7 @@ namespace alpaka_omp2_async {
   void mainRun(float dc,
                float rhoc,
                float dm,
+               float seed_dc,
                int pPBin,
                py::array_t<float> data,
                py::array_t<int> results,
@@ -47,7 +48,7 @@ namespace alpaka_omp2_async {
     const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
 
     // Create the queue
-    Queue queue_(dev_acc);
+    Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {
@@ -55,110 +56,120 @@ namespace alpaka_omp2_async {
         run<1, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (2):
         run<2, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (3):
         run<3, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (4):
         run<4, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (5):
         run<5, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (6):
         run<6, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (7):
         run<7, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (8):
         run<8, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (9):
         run<9, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (10):
         run<10, Kernel>(dc,
                         rhoc,
                         dm,
+                        seed_dc,
                         pPBin,
                         std::make_tuple(pData, pResults),
                         n_points,
                         kernel,
-                        queue_,
+                        queue,
                         block_size);
         return;
       [[unlikely]] default:
@@ -174,6 +185,7 @@ namespace alpaka_omp2_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -187,6 +199,7 @@ namespace alpaka_omp2_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -198,6 +211,7 @@ namespace alpaka_omp2_async {
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
+                                  float,
                                   float,
                                   float,
                                   int,

--- a/CLUEstering/BindingModules/serial/binding_cpu.cpp
+++ b/CLUEstering/BindingModules/serial/binding_cpu.cpp
@@ -32,6 +32,7 @@ namespace alpaka_serial_sync {
   void mainRun(float dc,
                float rhoc,
                float dm,
+               float seed_dc,
                int pPBin,
                py::array_t<float> data,
                py::array_t<int> results,
@@ -48,7 +49,7 @@ namespace alpaka_serial_sync {
     const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
 
     // Create the queue
-    Queue queue_(dev_acc);
+    Queue queue(dev_acc);
 
     // Running the clustering algorithm
     switch (Ndim) {
@@ -56,110 +57,120 @@ namespace alpaka_serial_sync {
         run<1, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (2):
         run<2, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (3):
         run<3, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (4):
         run<4, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (5):
         run<5, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (6):
         run<6, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (7):
         run<7, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (8):
         run<8, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (9):
         run<9, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (10):
         run<10, Kernel>(dc,
                         rhoc,
                         dm,
+                        seed_dc,
                         pPBin,
                         std::make_tuple(pData, pResults),
                         n_points,
                         kernel,
-                        queue_,
+                        queue,
                         block_size);
         return;
       [[unlikely]] default:
@@ -177,6 +188,7 @@ namespace alpaka_serial_sync {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -190,6 +202,7 @@ namespace alpaka_serial_sync {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -201,6 +214,7 @@ namespace alpaka_serial_sync {
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
+                                  float,
                                   float,
                                   float,
                                   int,

--- a/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
+++ b/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
@@ -31,6 +31,7 @@ namespace alpaka_tbb_async {
   void mainRun(float dc,
                float rhoc,
                float dm,
+               float seed_dc,
                int pPBin,
                py::array_t<float> data,
                py::array_t<int> results,
@@ -47,7 +48,7 @@ namespace alpaka_tbb_async {
     const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
 
     // Create the queue
-    Queue queue_(dev_acc);
+    Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {
@@ -55,110 +56,120 @@ namespace alpaka_tbb_async {
         run<1, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (2):
         run<2, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[likely]] case (3):
         run<3, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (4):
         run<4, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (5):
         run<5, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (6):
         run<6, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (7):
         run<7, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (8):
         run<8, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (9):
         run<9, Kernel>(dc,
                        rhoc,
                        dm,
+                       seed_dc,
                        pPBin,
                        std::make_tuple(pData, pResults),
                        n_points,
                        kernel,
-                       queue_,
+                       queue,
                        block_size);
         return;
       [[unlikely]] case (10):
         run<10, Kernel>(dc,
                         rhoc,
                         dm,
+                        seed_dc,
                         pPBin,
                         std::make_tuple(pData, pResults),
                         n_points,
                         kernel,
-                        queue_,
+                        queue,
                         block_size);
         return;
       [[unlikely]] default:
@@ -174,6 +185,7 @@ namespace alpaka_tbb_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -187,6 +199,7 @@ namespace alpaka_tbb_async {
           pybind11::overload_cast<float,
                                   float,
                                   float,
+                                  float,
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
@@ -198,6 +211,7 @@ namespace alpaka_tbb_async {
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
+                                  float,
                                   float,
                                   float,
                                   int,

--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -103,8 +103,7 @@ void run(const std::string& input_file) {
   clue::PointsDevice<2, Device> d_points(queue, n_points);
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
-  const int pPBin{128};
-  clue::Clusterer<2> algo(dc, rhoc, outlier, pPBin, queue);
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
   algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -27,8 +27,7 @@ void run(const std::string& input_file) {
   clue::PointsDevice<2, Device> d_points(queue, n_points);
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
-  const int pPBin{128};
-  clue::Clusterer<2> algo(dc, rhoc, outlier, pPBin, queue);
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
   algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);

--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -208,7 +208,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                                   TilesAlpakaView<Ndim>* dev_tiles,
                                   PointsView* dev_points,
                                   float dm,
-                                  float,
                                   uint32_t n_points) const {
       float dm_squared{dm * dm};
       for (auto i : alpaka::uniformElements(acc, n_points)) {
@@ -258,8 +257,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                                   VecArray<int32_t, max_followers>* followers,
                                   PointsView* dev_points,
                                   float dm,
-                                  float d_c,
-                                  float rho_c,
+                                  float seed_dc,
+                                  float rhoc,
                                   uint32_t n_points) const {
       for (auto i : alpaka::uniformElements(acc, n_points)) {
         // initialize cluster_index
@@ -269,8 +268,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
         float rho_i{dev_points->rho[i]};
 
         // Determine whether the point is a seed or an outlier
-        bool is_seed{(delta_i > d_c) && (rho_i >= rho_c)};
-        bool is_outlier{(delta_i > dm) && (rho_i < rho_c)};
+        bool is_seed{(delta_i > seed_dc) && (rho_i >= rhoc)};
+        bool is_outlier{(delta_i > dm) && (rho_i < rhoc)};
 
         if (is_seed) {
           dev_points->is_seed[i] = 1;

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -43,8 +43,12 @@ namespace clue {
         ALPAKA_ACCELERATOR_NAMESPACE_CLUE::max_followers;
     inline static constexpr auto reserve = ALPAKA_ACCELERATOR_NAMESPACE_CLUE::reserve;
 
-    explicit Clusterer(
-        float dc, float rhoc, float dm, int pPBin, Queue queue, float seed_dc = -1.f)
+    explicit Clusterer(Queue queue,
+                       float dc,
+                       float rhoc,
+                       float dm,
+                       float seed_dc = -1.f,
+                       int pPBin = 128)
         : m_dc{dc},
           m_seed_dc{seed_dc},
           m_rhoc{rhoc},
@@ -56,13 +60,13 @@ namespace clue {
       }
       init_device(queue);
     }
-    explicit Clusterer(float dc,
+    explicit Clusterer(Queue queue,
+                       TilesDevice* tile_buffer,
+                       float dc,
                        float rhoc,
                        float dm,
-                       int pPBin,
-                       Queue queue,
-                       TilesDevice* tile_buffer,
-                       float seed_dc = -1.f)
+                       float seed_dc = -1.f,
+                       int pPBin = 128)
         : m_dc{dc},
           m_seed_dc{seed_dc},
           m_rhoc{rhoc},

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -43,13 +43,35 @@ namespace clue {
         ALPAKA_ACCELERATOR_NAMESPACE_CLUE::max_followers;
     inline static constexpr auto reserve = ALPAKA_ACCELERATOR_NAMESPACE_CLUE::reserve;
 
-    explicit Clusterer(float dc, float rhoc, float dm, int pPBin, Queue queue)
-        : dc_{dc}, rhoc_{rhoc}, dm_{dm}, pointsPerTile_{pPBin}, m_wrappedCoordinates{} {
+    explicit Clusterer(
+        float dc, float rhoc, float dm, int pPBin, Queue queue, float seed_dc = -1.f)
+        : m_dc{dc},
+          m_seed_dc{seed_dc},
+          m_rhoc{rhoc},
+          m_dm{dm},
+          m_pointsPerTile{pPBin},
+          m_wrappedCoordinates{} {
+      if (seed_dc < 0.f) {
+        m_seed_dc = dc;
+      }
       init_device(queue);
     }
-    explicit Clusterer(
-        float dc, float rhoc, float dm, int pPBin, Queue queue, TilesDevice* tile_buffer)
-        : dc_{dc}, rhoc_{rhoc}, dm_{dm}, pointsPerTile_{pPBin}, m_wrappedCoordinates{} {
+    explicit Clusterer(float dc,
+                       float rhoc,
+                       float dm,
+                       int pPBin,
+                       Queue queue,
+                       TilesDevice* tile_buffer,
+                       float seed_dc = -1.f)
+        : m_dc{dc},
+          m_seed_dc{seed_dc},
+          m_rhoc{rhoc},
+          m_dm{dm},
+          m_pointsPerTile{pPBin},
+          m_wrappedCoordinates{} {
+      if (seed_dc < 0.f) {
+        m_seed_dc = dc;
+      }
       init_device(queue, tile_buffer);
     }
 
@@ -66,7 +88,7 @@ namespace clue {
     void make_clusters(PointsHost& h_points,
                        PointsDevice& d_points,
                        const KernelType& kernel,
-                       Queue queue_,
+                       Queue queue,
                        std::size_t block_size);
 
     void setWrappedCoordinates(const std::array<uint8_t, Ndim>& wrappedCoordinates) {
@@ -83,11 +105,11 @@ namespace clue {
     std::vector<std::vector<int>> getClusters(const PointsHost& h_points);
 
   private:
-    float dc_;
-    float rhoc_;
-    float dm_;
-    // average number of points found in a tile
-    int pointsPerTile_;
+    float m_dc;
+    float m_seed_dc;
+    float m_rhoc;
+    float m_dm;
+    int m_pointsPerTile;  // average number of points found in a tile
     std::array<uint8_t, Ndim> m_wrappedCoordinates;
 
     // internal buffers
@@ -97,8 +119,8 @@ namespace clue {
         d_followers;
     std::optional<PointsDevice> d_points;
 
-    void init_device(Queue queue_);
-    void init_device(Queue queue_, TilesDevice* tile_buffer);
+    void init_device(Queue queue);
+    void init_device(Queue queue, TilesDevice* tile_buffer);
 
     void setupTiles(Queue queue, const PointsHost& h_points);
     void setupPoints(const PointsHost& h_points,
@@ -140,10 +162,10 @@ namespace clue {
   }
 
   template <uint8_t Ndim>
-  void Clusterer<Ndim>::init_device(Queue queue_, TilesDevice* tile_buffer) {
-    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue_);
+  void Clusterer<Ndim>::init_device(Queue queue, TilesDevice* tile_buffer) {
+    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue);
     d_followers =
-        clue::make_device_buffer<VecArray<int32_t, max_followers>[]>(queue_, reserve);
+        clue::make_device_buffer<VecArray<int32_t, max_followers>[]>(queue, reserve);
 
     m_seeds = (*d_seeds).data();
     m_followers = (*d_followers).data();
@@ -157,7 +179,7 @@ namespace clue {
   void Clusterer<Ndim>::setupTiles(Queue queue, const PointsHost& h_points) {
     // TODO: reconsider the way that we compute the number of tiles
     auto nTiles = static_cast<int32_t>(
-        std::ceil(h_points.size() / static_cast<float>(pointsPerTile_)));
+        std::ceil(h_points.size() / static_cast<float>(m_pointsPerTile)));
     const auto nPerDim = static_cast<int32_t>(std::ceil(std::pow(nTiles, 1. / Ndim)));
     nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
 
@@ -243,15 +265,14 @@ namespace clue {
                         m_tiles,
                         dev_points.view(),
                         kernel,
-                        dc_,
+                        m_dc,
                         nPoints);
     alpaka::exec<Acc1D>(queue,
                         working_div,
                         KernelCalculateNearestHigher{},
                         m_tiles,
                         dev_points.view(),
-                        dm_,
-                        dc_,
+                        m_dm,
                         nPoints);
     alpaka::exec<Acc1D>(queue,
                         working_div,
@@ -259,9 +280,9 @@ namespace clue {
                         m_seeds,
                         m_followers,
                         dev_points.view(),
-                        dm_,
-                        dc_,
-                        rhoc_,
+                        m_dm,
+                        m_seed_dc,
+                        m_rhoc,
                         nPoints);
 
     // We change the working division when assigning the clusters

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -27,8 +27,7 @@ TEST_CASE("Test clustering on benchmarking datasets") {
     clue::PointsDevice<2, Device> d_points(queue, n_points);
 
     const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
-    const int pPBin{128};
-    clue::Clusterer<2> algo(dc, rhoc, outlier, pPBin, queue);
+    clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
     const std::size_t block_size{256};
     algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
@@ -56,8 +55,7 @@ TEST_CASE("Test clustering on sissa") {
   clue::PointsDevice<2, Device> d_points(queue, n_points);
 
   const float dc{20.f}, rhoc{10.f}, outlier{20.f};
-  const int pPBin{128};
-  clue::Clusterer<2> algo(dc, rhoc, outlier, pPBin, queue);
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
   algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
@@ -83,8 +81,7 @@ TEST_CASE("Test clustering on toy detector dataset") {
   clue::PointsDevice<2, Device> d_points(queue, n_points);
 
   const float dc{4.5f}, rhoc{2.5f}, outlier{4.5f};
-  const int pPBin{128};
-  clue::Clusterer<2> algo(dc, rhoc, outlier, pPBin, queue);
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
   algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
@@ -110,8 +107,7 @@ TEST_CASE("Test clustering on blob dataset") {
   clue::PointsDevice<3, Device> d_points(queue, n_points);
 
   const float dc{1.f}, rhoc{5.f}, outlier{2.f};
-  const int pPBin{128};
-  clue::Clusterer<3> algo(dc, rhoc, outlier, pPBin, queue);
+  clue::Clusterer<3> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
   algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);


### PR DESCRIPTION
This PR separates the `dc` parameter in two:
* the usual one, now only used for the calculation of local density
* a new one, `seed_dc` used in the kernel for finding clusters
* also, reorder the clusterer constructor arguments, putting the Queue as first argument
* default initialize `pointsPerTile` to 128