### PR TITLE
Feature Alpaka-OpenMP backend

### DIFF
--- a/.github/workflows/bench_profile_serial.yml
+++ b/.github/workflows/bench_profile_serial.yml
@@ -26,6 +26,7 @@ jobs:
         pip install matplotlib
         sudo apt install -y libboost-dev
         sudo apt install -y libtbb-dev
+        sudo apt install libomp-dev
 
     - name: Compile and run benchmark
       working-directory: ${{ github.workspace }}/benchmark/dataset_size
@@ -36,6 +37,8 @@ jobs:
         ./build/serial.out 10 18
         echo "Running TBB backend"
         ./build/tbb.out 10 18
+        echo "Running OpenMP backend"
+        ./build/openmp.out 10 18
 
     # TODO: this works on local but not on github actions
     # - name: Compile and run profiling

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,7 @@ jobs:
         python -m pip install matplotlib
         sudo apt install -y libboost-dev
         sudo apt install -y libtbb-dev
+        sudo apt install libomp-dev
     - name: Compile CLUEstering modules
       working-directory: ${{github.workspace}}
       run: |

--- a/CLUEstering/BindingModules/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/binding_cpu_omp.cpp
@@ -1,0 +1,213 @@
+
+#include <alpaka/alpaka.hpp>
+#include <vector>
+
+#include "Run.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+namespace alpaka_omp2_async {
+
+  void listDevices(const std::string& backend) {
+    const char tab = '\t';
+    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    if (devices.empty()) {
+      std::cout << "No devices found for the " << backend << " backend." << std::endl;
+      return;
+    } else {
+      std::cout << backend << " devices found: \n";
+      for (size_t i{}; i < devices.size(); ++i) {
+        std::cout << tab << "Device " << i << ": " << alpaka::getName(devices[i]) << '\n';
+      }
+    }
+  }
+
+  template <typename Kernel>
+  void mainRun(float dc,
+               float rhoc,
+               float dm,
+               int pPBin,
+               py::array_t<float> data,
+               py::array_t<int> results,
+               const Kernel& kernel,
+               int Ndim,
+               uint32_t n_points,
+               size_t block_size,
+               size_t device_id) {
+    auto rData = data.request();
+    float* pData = static_cast<float*>(rData.ptr);
+    auto rResults = results.request();
+    int* pResults = static_cast<int*>(rResults.ptr);
+
+    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+
+    // Create the queue
+    Queue queue_(dev_acc);
+
+    // Running the clustering algorithm //
+    switch (Ndim) {
+      [[unlikely]] case (1):
+        run<1, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<1>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[likely]] case (2):
+        run<2, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<2>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[likely]] case (3):
+        run<3, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<3>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (4):
+        run<4, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<4>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (5):
+        run<5, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<5>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (6):
+        run<6, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<6>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (7):
+        run<7, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<7>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (8):
+        run<8, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<8>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (9):
+        run<9, Kernel>(dc,
+                       rhoc,
+                       dm,
+                       pPBin,
+                       std::make_tuple(pData, pResults),
+                       PointInfo<9>{n_points},
+                       kernel,
+                       queue_,
+                       block_size);
+        return;
+      [[unlikely]] case (10):
+        run<10, Kernel>(dc,
+                        rhoc,
+                        dm,
+                        pPBin,
+                        std::make_tuple(pData, pResults),
+                        PointInfo<10>{n_points},
+                        kernel,
+                        queue_,
+                        block_size);
+        return;
+      [[unlikely]] default:
+        std::cout << "This library only works up to 10 dimensions\n";
+    }
+  }
+
+  PYBIND11_MODULE(CLUE_CPU_TBB, m) {
+    m.doc() = "Binding of the CLUE algorithm running on CPU with TBB";
+
+    m.def("listDevices", &listDevices, "List the available devices for the TBB backend");
+    m.def("mainRun",
+          pybind11::overload_cast<float,
+                                  float,
+                                  float,
+                                  int,
+                                  py::array_t<float>,
+                                  py::array_t<int>,
+                                  const FlatKernel&,
+                                  int,
+                                  uint32_t,
+                                  size_t,
+                                  size_t>(&mainRun<FlatKernel>),
+          "mainRun");
+    m.def("mainRun",
+          pybind11::overload_cast<float,
+                                  float,
+                                  float,
+                                  int,
+                                  py::array_t<float>,
+                                  py::array_t<int>,
+                                  const ExponentialKernel&,
+                                  int,
+                                  uint32_t,
+                                  size_t,
+                                  size_t>(&mainRun<ExponentialKernel>),
+          "mainRun");
+    m.def("mainRun",
+          pybind11::overload_cast<float,
+                                  float,
+                                  float,
+                                  int,
+                                  py::array_t<float>,
+                                  py::array_t<int>,
+                                  const GaussianKernel&,
+                                  int,
+                                  uint32_t,
+                                  size_t,
+                                  size_t>(&mainRun<GaussianKernel>),
+          "mainRun");
+  }
+};  // namespace alpaka_omp2_async

--- a/CLUEstering/BindingModules/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/binding_cpu_omp.cpp
@@ -166,7 +166,7 @@ namespace alpaka_omp2_async {
     }
   }
 
-  PYBIND11_MODULE(CLUE_CPU_TBB, m) {
+  PYBIND11_MODULE(CLUE_CPU_OMP, m) {
     m.doc() = "Binding of the CLUE algorithm running on CPU with TBB";
 
     m.def("listDevices", &listDevices, "List the available devices for the TBB backend");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if(OpenMP_CXX_FOUND)
     ${CMAKE_SOURCE_DIR}/CLUEstering/BindingModules/binding_cpu_omp.cpp)
   target_include_directories(
     CLUE_CPU_OMP PRIVATE ${CMAKE_SOURCE_DIR}/include
-                         ${alpaka_SOURCE_DIR}/include ${Boost_SOURCE_DIR})
+                         ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
   target_compile_definitions(
     CLUE_CPU_OMP PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
   target_link_libraries(CLUE_CPU_OMP PRIVATE OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,31 @@ if(TBB_FOUND)
     COMMENT "Copying module to ${CMAKE_SOURCE_DIR}/CLUEstering/lib")
 endif()
 
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  pybind11_add_module(
+    CLUE_CPU_OMP SHARED
+    ${CMAKE_SOURCE_DIR}/CLUEstering/BindingModules/binding_cpu_omp.cpp)
+  target_include_directories(
+    CLUE_CPU_OMP PRIVATE ${CMAKE_SOURCE_DIR}/include
+                         ${alpaka_SOURCE_DIR}/include ${Boost_SOURCE_DIR})
+  target_compile_definitions(
+    CLUE_CPU_OMP PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+  target_link_libraries(CLUE_CPU_TBB PRIVATE OpenMP::OpenMP_CXX)
+  set_target_properties(
+    CLUE_CPU_OMP PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                            ${CMAKE_BINARY_DIR}/lib/CLUEstering/lib/)
+  # copy shared library for local testing
+  add_custom_command(
+    TARGET CLUE_CPU_OMP
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy
+      ${CMAKE_BINARY_DIR}/lib/CLUEstering/lib/CLUE_CPU_OMP.*
+      ${CMAKE_SOURCE_DIR}/CLUEstering/lib/
+    COMMENT "Copying module to ${CMAKE_SOURCE_DIR}/CLUEstering/lib")
+endif()
+
 # check if CUDA is available
 include(CheckLanguage)
 check_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(TBB_FOUND)
 endif()
 
 find_package(OpenMP)
+# CPU OpenMP
 if(OpenMP_CXX_FOUND)
   pybind11_add_module(
     CLUE_CPU_OMP SHARED
@@ -116,7 +117,7 @@ if(OpenMP_CXX_FOUND)
                          ${alpaka_SOURCE_DIR}/include ${Boost_SOURCE_DIR})
   target_compile_definitions(
     CLUE_CPU_OMP PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
-  target_link_libraries(CLUE_CPU_TBB PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(CLUE_CPU_OMP PRIVATE OpenMP::OpenMP_CXX)
   set_target_properties(
     CLUE_CPU_OMP PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                             ${CMAKE_BINARY_DIR}/lib/CLUEstering/lib/)

--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -49,6 +49,18 @@ if(TBB_FOUND)
                                              ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
 endif()
 
+find_package(OpenMP)
+# CPU OpenMP
+if(OpenMP_CXX_FOUND)
+  add_executable(openmp.out main.cpp)
+  target_include_directories(
+    openmp.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  target_link_libraries(openmp.out PRIVATE pybind11::embed OpenMP::OpenMP_CXX)
+  target_compile_definitions(
+    openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+endif()
+
 # check if CUDA is available
 include(CheckLanguage)
 check_language(CUDA)

--- a/benchmark/profiling/CMakeLists.txt
+++ b/benchmark/profiling/CMakeLists.txt
@@ -10,11 +10,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-string(
-  APPEND
-  CMAKE_CXX_FLAGS_DEBUG
-  " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg"
-)
+string(APPEND CMAKE_CXX_FLAGS_DEBUG
+       " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg")
 string(APPEND CMAKE_CXX_FLAGS "-O2")
 
 find_package(Boost 1.75.0 REQUIRED)
@@ -43,6 +40,18 @@ if(TBB_FOUND)
   target_link_libraries(tbb.out PRIVATE TBB::tbb)
   target_compile_definitions(tbb.out PRIVATE ALPAKA_HOST_ONLY
                                              ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
+endif()
+
+find_package(OpenMP)
+# CPU OpenMP
+if(OpenMP_CXX_FOUND)
+  add_executable(openmp.out main.cpp)
+  target_include_directories(
+    openmp.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX)
+  target_compile_definitions(
+    openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
 endif()
 
 include(CheckLanguage)

--- a/include/CLUEstering/test/CMakeLists.txt
+++ b/include/CLUEstering/test/CMakeLists.txt
@@ -9,9 +9,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "-Wall -Wextra -g -O0")
-endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG
+       " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg")
+string(APPEND CMAKE_CXX_FLAGS "-O2")
 
 find_package(Boost 1.75.0 REQUIRED)
 
@@ -25,8 +25,6 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS)
 FetchContent_MakeAvailable(alpaka)
 
-include_directories(../../../CLUEstering)
-
 include(FetchContent)
 # Get doctest
 FetchContent_Declare(
@@ -39,28 +37,50 @@ if(NOT doctest_POPULATED)
 endif()
 
 add_executable(serial.out TestTilesExternal.cpp)
-target_include_directories(serial.out SYSTEM
-                           PRIVATE ${doctest_SOURCE_DIR}/doctest)
-target_include_directories(serial.out PRIVATE ${alpaka_SOURCE_DIR}/include
-                                              ${Boost_INCLUDE_DIR})
-target_compile_options(serial.out PRIVATE -DALPAKA_HOST_ONLY
-                                          -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
+target_include_directories(
+  serial.out
+  PRIVATE ${CMAKE_SURCE_DIR}../../../CLUEstering ${doctest_SOURCE_DIR}/doctest
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+target_compile_definitions(
+  serial.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
 
-add_executable(tbb.out TestTilesExternal.cpp)
-target_include_directories(tbb.out SYSTEM PRIVATE ${doctest_SOURCE_DIR}/doctest)
-target_include_directories(tbb.out PRIVATE ${alpaka_SOURCE_DIR}/include
-                                           ${Boost_INCLUDE_DIR})
-target_compile_options(tbb.out PRIVATE -DALPAKA_HOST_ONLY
-                                       -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
+find_package(TBB)
+if(TBB_FOUND)
+  add_executable(tbb.out TestTilesExternal.cpp)
+  target_include_directories(
+    tbb.out
+    PRIVATE ${CMAKE_SURCE_DIR}../../../CLUEstering
+            ${doctest_SOURCE_DIR}/doctest ${alpaka_SOURCE_DIR}/include
+            ${Boost_INCLUDE_DIR})
+  target_link_libraries(tbb.out PRIVATE TBB::tbb)
+  target_compile_definitions(tbb.out PRIVATE ALPAKA_HOST_ONLY
+                                             ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
+endif()
+
+find_package(OpenMP)
+# CPU OpenMP
+if(OpenMP_CXX_FOUND)
+  add_executable(openmp.out TestTilesExternal.cpp)
+  target_include_directories(
+    openmp.out
+    PRIVATE ${CMAKE_SURCE_DIR}../../../CLUEstering
+            ${doctest_SOURCE_DIR}/doctest ${alpaka_SOURCE_DIR}/include
+            ${Boost_INCLUDE_DIR})
+  target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX)
+  target_compile_definitions(
+    openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+endif()
 
 include(CheckLanguage)
 check_language(CUDA)
 
-if (CMAKE_CUDA_COMPILER)
-add_executable(cuda.out TestTilesExternal.cpp)
-target_include_directories(cuda.out SYSTEM PRIVATE ${doctest_SOURCE_DIR}/doctest)
-target_include_directories(cuda.out PRIVATE ${alpaka_SOURCE_DIR}/include
-                                           ${Boost_INCLUDE_DIR})
-target_compile_options(cuda.out PRIVATE -DALPAKA_HOST_ONLY
-										-DALPAKA_ACC_GPU_CUDA_ENABLED)
+if(CMAKE_CUDA_COMPILER)
+  add_executable(cuda.out TestTilesExternal.cpp)
+  target_include_directories(
+    cuda.out
+    PRIVATE ${CMAKE_SURCE_DIR}../../../CLUEstering
+            ${doctest_SOURCE_DIR}/doctest ${alpaka_SOURCE_DIR}/include
+            ${Boost_INCLUDE_DIR})
+  target_compile_options(cuda.out PRIVATE -DALPAKA_HOST_ONLY
+                                          -DALPAKA_ACC_GPU_CUDA_ENABLED)
 endif()


### PR DESCRIPTION
This PR adds the alpaka-based OpenMP backed for parallel execution on CPU, which serves as an alternative for the TBB backend.