### PR TITLE
Allow automatic vectorization and loop unrolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ string(
   CMAKE_CXX_FLAGS_DEBUG
   " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -Wpedantic -Wpedantic -Werror"
 )
-string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -ffast-math -funsafe-math-optimizations -ftree-vectorize -march=native")
 
 # include pybind11 extern subfolder
 set(PYBIND11_FINDPYTHON ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ string(
   CMAKE_CXX_FLAGS_DEBUG
   " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -Wpedantic -Wpedantic -Werror"
 )
-string(APPEND CMAKE_CXX_FLAGS "-O2")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
 
 # include pybind11 extern subfolder
 set(PYBIND11_FINDPYTHON ON)

--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -17,7 +17,7 @@ string(
   CMAKE_CXX_FLAGS_DEBUG
   " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -Wpedantic -Wpedantic -Werror"
 )
-string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -ffast-math -funsafe-math-optimizations -ftree-vectorize -march=native")
 
 add_subdirectory(pybind11)
 

--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -17,7 +17,7 @@ string(
   CMAKE_CXX_FLAGS_DEBUG
   " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -Wpedantic -Wpedantic -Werror"
 )
-string(APPEND CMAKE_CXX_FLAGS "-O2")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
 
 add_subdirectory(pybind11)
 

--- a/benchmark/profiling/CMakeLists.txt
+++ b/benchmark/profiling/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 string(APPEND CMAKE_CXX_FLAGS_DEBUG
        " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg")
-string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -fopt-info-vec -ftree-vectorize -march=native")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -ffast-math -funsafe-math-optimizations -fopt-info-vec -ftree-vectorize -march=native")
 
 find_package(Boost 1.75.0 REQUIRED)
 

--- a/benchmark/profiling/CMakeLists.txt
+++ b/benchmark/profiling/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 string(APPEND CMAKE_CXX_FLAGS_DEBUG
        " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg")
-string(APPEND CMAKE_CXX_FLAGS "-O2")
+string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -fopt-info-vec -ftree-vectorize -march=native")
 
 find_package(Boost 1.75.0 REQUIRED)
 


### PR DESCRIPTION
The benchmark below shows that enabling auto-vectorization and loop-unrolling gives a non-negligible boost in performance for the serial backend
![image](https://github.com/user-attachments/assets/2121b6f8-c1ff-47a6-8914-1ebfadabd9bd)
