### PR TITLE
Allow vectorization in density kernel

### DIFF
--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -64,10 +64,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
         float dist_ij_sq = tiles->distance(coords_i, coords_j);
 
-        if (dist_ij_sq <= dc * dc) {
-          *rho_i += kernel(acc, alpaka::math::sqrt(acc, dist_ij_sq), point_id, j) *
-                    dev_points->weight[j];
-        }
+        auto k = kernel(acc, alpaka::math::sqrt(acc, dist_ij_sq), point_id, j);
+        *rho_i += (int)(dist_ij_sq <= dc * dc) * k * dev_points->weight[j];
 
       }  // end of interate inside this bin
       return;


### PR DESCRIPTION
This PR modifies the kernel for the calculation of local density in order to improve vectorization.
![image](https://github.com/user-attachments/assets/feff8798-1ca6-4451-acc9-d2df37b637c6)

