### PR TITLE
Remove ALPAKA_ACCELERATOR_NAMESPACE from PointsAlpaka and TilesAlpaka

### DIFF
--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -20,7 +20,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
     // Create the host and device points
     PointsSoA<Ndim> h_points(std::get<0>(pData), std::get<1>(pData), shape);
-    PointsAlpaka<Ndim> d_points(queue_, shape.nPoints);
+    clue::PointsAlpaka<Ndim, Device> d_points(queue_, shape.nPoints);
 
     algo.make_clusters(h_points, d_points, kernel, queue_, block_size);
   }

--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -93,7 +93,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
     PointsSoA<2> h_points(
         coords.data(), results.data(), PointInfo<2>{(uint32_t)n_points});
-    PointsAlpaka<2> d_points(queue_, n_points);
+    clue::PointsAlpaka<2, Device> d_points(queue_, n_points);
 
     const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
     const int pPBin{128};

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -21,7 +21,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
     PointsSoA<2> h_points(
         coords.data(), results.data(), PointInfo<2>{static_cast<uint32_t>(n_points)});
-    PointsAlpaka<2> d_points(queue_, n_points);
+    clue::PointsAlpaka<2, Device> d_points(queue_, n_points);
 
     const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
     const int pPBin{128};

--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -11,6 +11,8 @@
 #include "../DataFormats/alpaka/AlpakaVecArray.hpp"
 #include "ConvolutionalKernel.hpp"
 
+using clue::PointsAlpakaView;
+using clue::TilesAlpakaView;
 using clue::VecArray;
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -1,6 +1,13 @@
 
 #pragma once
 
+#include "DataFormats/Points.hpp"
+#include "DataFormats/alpaka/PointsAlpaka.hpp"
+#include "DataFormats/alpaka/TilesAlpaka.hpp"
+#include "CLUE/CLUEAlpakaKernels.hpp"
+#include "CLUE/ConvolutionalKernel.hpp"
+#include "utility/validation.hpp"
+
 #include <algorithm>
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/vec/Vec.hpp>
@@ -10,30 +17,21 @@
 #include <utility>
 #include <vector>
 
-#include "DataFormats/Points.hpp"
-#include "DataFormats/alpaka/PointsAlpaka.hpp"
-#include "DataFormats/alpaka/TilesAlpaka.hpp"
-#include "CLUE/CLUEAlpakaKernels.hpp"
-#include "CLUE/ConvolutionalKernel.hpp"
-#include "utility/validation.hpp"
-
-using clue::VecArray;
-
 namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
   template <uint8_t Ndim>
   class CLUEAlgoAlpaka {
   public:
+    using CoordinateExtremes = clue::CoordinateExtremes<Ndim>;
+    using PointsDevice = clue::PointsAlpaka<Ndim, Device>;
+    using TilesDevice = clue::TilesAlpaka<Ndim, Device>;
+
     explicit CLUEAlgoAlpaka(float dc, float rhoc, float dm, int pPBin, Queue queue)
         : dc_{dc}, rhoc_{rhoc}, dm_{dm}, pointsPerTile_{pPBin} {
       init_device(queue);
     }
-    explicit CLUEAlgoAlpaka(float dc,
-                            float rhoc,
-                            float dm,
-                            int pPBin,
-                            Queue queue,
-                            TilesAlpaka<Ndim>* tile_buffer)
+    explicit CLUEAlgoAlpaka(
+        float dc, float rhoc, float dm, int pPBin, Queue queue, TilesDevice* tile_buffer)
         : dc_{dc}, rhoc_{rhoc}, dm_{dm}, pointsPerTile_{pPBin} {
       init_device(queue, tile_buffer);
     }
@@ -49,7 +47,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                        std::size_t block_size);
     template <typename KernelType>
     void make_clusters(PointsSoA<Ndim>& h_points,
-                       PointsAlpaka<Ndim>& d_points,
+                       PointsDevice& d_points,
                        const KernelType& kernel,
                        Queue queue_,
                        std::size_t block_size);
@@ -64,29 +62,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
     int pointsPerTile_;
 
     // internal buffers
-    std::optional<TilesAlpaka<Ndim>> d_tiles;
+    std::optional<TilesDevice> d_tiles;
     std::optional<clue::device_buffer<Device, VecArray<int32_t, reserve>>> d_seeds;
     std::optional<clue::device_buffer<Device, clue::VecArray<int32_t, max_followers>[]>>
         d_followers;
-    std::optional<PointsAlpaka<Ndim>> d_points;
+    std::optional<PointsDevice> d_points;
 
     void init_device(Queue queue_);
-    void init_device(Queue queue_, TilesAlpaka<Ndim>* tile_buffer);
+    void init_device(Queue queue_, TilesDevice* tile_buffer);
 
     void setupTiles(Queue queue, const PointsSoA<Ndim>& h_points);
     void setupPoints(const PointsSoA<Ndim>& h_points,
-                     PointsAlpaka<Ndim>& dev_points,
+                     PointsDevice& dev_points,
                      Queue queue,
                      std::size_t block_size);
 
-    void calculate_tile_size(CoordinateExtremes<Ndim>* min_max,
+    void calculate_tile_size(CoordinateExtremes* min_max,
                              float* tile_sizes,
                              const PointsSoA<Ndim>& h_points,
                              uint32_t nPerDim);
   };
 
   template <uint8_t Ndim>
-  void CLUEAlgoAlpaka<Ndim>::calculate_tile_size(CoordinateExtremes<Ndim>* min_max,
+  void CLUEAlgoAlpaka<Ndim>::calculate_tile_size(CoordinateExtremes* min_max,
                                                  float* tile_sizes,
                                                  const PointsSoA<Ndim>& h_points,
                                                  uint32_t nPerDim) {
@@ -117,7 +115,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
   }
 
   template <uint8_t Ndim>
-  void CLUEAlgoAlpaka<Ndim>::init_device(Queue queue_, TilesAlpaka<Ndim>* tile_buffer) {
+  void CLUEAlgoAlpaka<Ndim>::init_device(Queue queue_, TilesDevice* tile_buffer) {
     d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue_);
     d_followers =
         clue::make_device_buffer<VecArray<int32_t, max_followers>[]>(queue_, reserve);
@@ -139,7 +137,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
     nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
 
     if (!d_tiles.has_value()) {
-      d_tiles = std::make_optional<TilesAlpaka<Ndim>>(queue, h_points.nPoints(), nTiles);
+      d_tiles = std::make_optional<TilesDevice>(queue, h_points.nPoints(), nTiles);
       m_tiles = d_tiles->view();
     }
     // check if tiles are large enough for current data
@@ -152,7 +150,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
       d_tiles->reset(h_points.nPoints(), nTiles, nPerDim, queue);
     }
 
-    auto min_max = clue::make_host_buffer<CoordinateExtremes<Ndim>>(queue);
+    auto min_max = clue::make_host_buffer<CoordinateExtremes>(queue);
     auto tile_sizes = clue::make_host_buffer<float[Ndim]>(queue);
     calculate_tile_size(min_max.data(), tile_sizes.data(), h_points, nPerDim);
 
@@ -166,7 +164,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
   template <uint8_t Ndim>
   void CLUEAlgoAlpaka<Ndim>::setupPoints(const PointsSoA<Ndim>& h_points,
-                                         PointsAlpaka<Ndim>& dev_points,
+                                         PointsDevice& dev_points,
                                          Queue queue,
                                          std::size_t block_size) {
     const auto copyExtent = (Ndim + 1) * h_points.nPoints();
@@ -190,7 +188,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                                            const KernelType& kernel,
                                            Queue queue,
                                            std::size_t block_size) {
-    d_points = std::make_optional<PointsAlpaka<Ndim>>(queue, h_points.nPoints());
+    d_points = std::make_optional<PointsDevice>(queue, h_points.nPoints());
     auto& dev_points = *d_points;
     make_clusters(h_points, dev_points, kernel, queue, block_size);
   }
@@ -198,7 +196,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
   template <uint8_t Ndim>
   template <typename KernelType>
   void CLUEAlgoAlpaka<Ndim>::make_clusters(PointsSoA<Ndim>& h_points,
-                                           PointsAlpaka<Ndim>& dev_points,
+                                           PointsDevice& dev_points,
                                            const KernelType& kernel,
                                            Queue queue,
                                            std::size_t block_size) {
@@ -208,7 +206,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
     const auto nPoints = h_points.nPoints();
 
     // fill the tiles
-    d_tiles->fill(queue, dev_points, nPoints);
+    d_tiles->template fill<Acc1D>(queue, dev_points, nPoints);
 
     const Idx grid_size = clue::divide_up_by(nPoints, block_size);
     auto working_div = clue::make_workdiv<Acc1D>(grid_size, block_size);

--- a/include/CLUEstering/DataFormats/alpaka/PointsAlpaka.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/PointsAlpaka.hpp
@@ -23,10 +23,10 @@ namespace clue {
   };
 
   template <uint8_t Ndim, typename TDev>
-	requires alpaka::isDevice<TDev>
+    requires alpaka::isDevice<TDev>
   class PointsAlpaka {
   public:
-	template <typename TQueue>
+    template <typename TQueue>
     explicit PointsAlpaka(TQueue stream, int n_points)
         : input_buffer{clue::make_device_buffer<float[]>(stream, (Ndim + 3) * n_points)},
           result_buffer{clue::make_device_buffer<int[]>(stream, 3 * n_points)},
@@ -58,6 +58,6 @@ namespace clue {
   private:
     clue::device_buffer<TDev, PointsAlpakaView> view_dev;
   };
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE
+}  // namespace clue
 
 #endif

--- a/include/CLUEstering/DataFormats/alpaka/PointsAlpaka.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/PointsAlpaka.hpp
@@ -8,7 +8,7 @@
 #include "../../AlpakaCore/alpakaMemory.hpp"
 #include "../Points.hpp"
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
+namespace clue {
 
   class PointsAlpakaView {
   public:
@@ -22,11 +22,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
     int n;
   };
 
-  template <uint8_t Ndim>
+  template <uint8_t Ndim, typename TDev>
+	requires alpaka::isDevice<TDev>
   class PointsAlpaka {
   public:
-    PointsAlpaka() = delete;
-    explicit PointsAlpaka(Queue stream, int n_points)
+	template <typename TQueue>
+    explicit PointsAlpaka(TQueue stream, int n_points)
         : input_buffer{clue::make_device_buffer<float[]>(stream, (Ndim + 3) * n_points)},
           result_buffer{clue::make_device_buffer<int[]>(stream, 3 * n_points)},
           view_dev{clue::make_device_buffer<PointsAlpakaView>(stream)} {
@@ -49,13 +50,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
     PointsAlpaka& operator=(PointsAlpaka&&) = default;
     ~PointsAlpaka() = default;
 
-    clue::device_buffer<Device, float[]> input_buffer;
-    clue::device_buffer<Device, int[]> result_buffer;
+    clue::device_buffer<TDev, float[]> input_buffer;
+    clue::device_buffer<TDev, int[]> result_buffer;
 
     PointsAlpakaView* view() { return view_dev.data(); }
 
   private:
-    clue::device_buffer<Device, PointsAlpakaView> view_dev;
+    clue::device_buffer<TDev, PointsAlpakaView> view_dev;
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE
 


### PR DESCRIPTION
This PR moves the TilesAlpaka and PointsAlpaka classes in the `clue` namespace instead of `ALPAKA_ACCELERATOR_NAMESPACE`. This will be needed by later PRs extending the C++ interface for making it less cumbersome to use.