### PR TITLE
Only plot dset bench results if pybind globally available

### DIFF
--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -27,6 +27,7 @@ if (pybind11_FOUND)
   add_definitions(-DPYBIND11)
 else()
   set(pybind_link "")
+  message(STATUS "pybind11 not found, so no plots will be generated.")
 endif()
 
 include(FetchContent)

--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -19,9 +19,15 @@ string(
 )
 string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
 
-add_subdirectory(pybind11)
-
 find_package(Boost 1.75.0 REQUIRED)
+find_package(pybind11)
+
+if (pybind11_FOUND)
+  set(pybind_link pybind11::embed)
+  add_definitions(-DPYBIND11)
+else()
+  set(pybind_link "")
+endif()
 
 include(FetchContent)
 FetchContent_Declare(

--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -17,12 +17,16 @@ string(
   CMAKE_CXX_FLAGS_DEBUG
   " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -Wpedantic -Wpedantic -Werror"
 )
-string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native")
+string(
+  APPEND
+  CMAKE_CXX_FLAGS
+  "-O2 -funroll-loops -funsafe-math-optimizations -ftree-vectorize -march=native"
+)
 
 find_package(Boost 1.75.0 REQUIRED)
 find_package(pybind11)
 
-if (pybind11_FOUND)
+if(pybind11_FOUND)
   set(pybind_link pybind11::embed)
   add_definitions(-DPYBIND11)
 else()
@@ -45,21 +49,28 @@ if(CMAKE_CUDA_COMPILER)
   add_subdirectory(cuda)
 endif()
 
-SET(_sycl_search_dirs ${SYCL_ROOT_DIR} /usr/lib /usr/local/lib /opt/intel/oneapi/compiler/latest/linux)
-find_program(SYCL_COMPILER
-			NAMES icpx
-			HINTS ${_sycl_search_dirs}
-			PATH_SUFFIXES bin)
-find_path(SYCL_INCLUDE_DIR
-		 NAMES sycl/sycl.hpp
-		 HINTS ${_sycl_search_dirs}
-		 PATH_SUFFIXES include)
-find_path(SYCL_LIB_DIR
-		 NAMES libsycl.so
-		 HINTS ${_sycl_search_dirs}
-		 PATH_SUFFIXES lib)
+set(_sycl_search_dirs ${SYCL_ROOT_DIR} /usr/lib /usr/local/lib
+                      /opt/intel/oneapi/compiler/latest/linux)
+find_program(
+  SYCL_COMPILER
+  NAMES icpx
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES bin)
+find_path(
+  SYCL_INCLUDE_DIR
+  NAMES sycl/sycl.hpp
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES include)
+find_path(
+  SYCL_LIB_DIR
+  NAMES libsycl.so
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES lib)
 find_package(oneDPL)
 
-if (oneDPL_FOUND AND SYCL_COMPILER AND SYCL_INCLUDE_DIR AND SYCL_LIB_DIR)
+if(oneDPL_FOUND
+   AND SYCL_COMPILER
+   AND SYCL_INCLUDE_DIR
+   AND SYCL_LIB_DIR)
   add_subdirectory(sycl)
 endif()

--- a/benchmark/dataset_size/cpu/CMakeLists.txt
+++ b/benchmark/dataset_size/cpu/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(serial.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
   serial.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
                      ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-target_link_libraries(serial.out PRIVATE pybind11::embed)
+target_link_libraries(serial.out PRIVATE ${pybind_link})
 target_compile_definitions(
   serial.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
 
@@ -15,7 +15,7 @@ if(TBB_FOUND)
   target_include_directories(
     tbb.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
                     ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-  target_link_libraries(tbb.out PRIVATE pybind11::embed TBB::tbb)
+  target_link_libraries(tbb.out PRIVATE ${pybind_link} TBB::tbb)
   target_compile_definitions(tbb.out PRIVATE ALPAKA_HOST_ONLY
                                              ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
 endif()
@@ -27,7 +27,7 @@ if(OpenMP_CXX_FOUND)
   target_include_directories(
     openmp.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
                        ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-  target_link_libraries(openmp.out PRIVATE pybind11::embed OpenMP::OpenMP_CXX)
+  target_link_libraries(openmp.out PRIVATE ${pybind_link} OpenMP::OpenMP_CXX)
   target_compile_definitions(
     openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
   set_target_properties(

--- a/benchmark/dataset_size/cuda/CMakeLists.txt
+++ b/benchmark/dataset_size/cuda/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(cuda.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
   cuda.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
 				   ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-target_link_libraries(cuda.out PRIVATE pybind11::embed)
+target_link_libraries(cuda.out PRIVATE ${pybind_link})
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
 set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON

--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -14,6 +14,7 @@
 
 #include "CLUEstering/utility/read_csv.hpp"
 
+#ifdef PYBIND11
 #include <pybind11/embed.h>
 #include <pybind11/stl_bind.h>
 
@@ -22,6 +23,7 @@ using namespace pybind11::literals;
 
 PYBIND11_MAKE_OPAQUE(std::vector<int>);
 PYBIND11_MAKE_OPAQUE(std::vector<float>);
+#endif
 
 struct TimeMeasures {
   std::vector<int> sizes;
@@ -54,6 +56,7 @@ std::vector<std::string> GetFiles(int min, int max) {
   return files;
 }
 
+#ifdef PYBIND11
 void plot(const TimeMeasures& measures, const std::string& filename) {
   py::scoped_interpreter guard{};
   py::module plt = py::module::import("matplotlib.pyplot");
@@ -66,6 +69,7 @@ void plot(const TimeMeasures& measures, const std::string& filename) {
   plt.attr("grid")("ls"_a = "--", "lw"_a = .5);
   plt.attr("savefig")(filename);
 }
+#endif
 
 void to_csv(const TimeMeasures& measures, const std::string& filename) {
   std::ofstream file{filename};
@@ -150,6 +154,8 @@ int main(int argc, char* argv[]) {
       });
 
   auto figname = oFilename.substr(0, oFilename.find_last_of('.')) + ".pdf";
+#ifdef PYBIND11
   plot(measures, figname);
+#endif
   to_csv(measures, oFilename);
 }

--- a/benchmark/dataset_size/pybind11
+++ b/benchmark/dataset_size/pybind11
@@ -1,1 +1,0 @@
-../../extern/pybind11

--- a/benchmark/dataset_size/sycl/CMakeLists.txt
+++ b/benchmark/dataset_size/sycl/CMakeLists.txt
@@ -4,12 +4,11 @@ add_executable(sycl_cpu.out ../main.cpp)
 target_include_directories(sycl_cpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
 												${alpaka_SOURCE_DIR}/include
 												${Boost_INCLUDE_DIR})
-target_link_libraries(sycl_cpu.out PRIVATE pybind11::embed)
 target_include_directories(sycl_cpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_cpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
 											-DALPAKA_SYCL_ONEAPI_CPU
 											-fsycl)
-target_link_libraries(sycl_cpu.out PRIVATE -fsycl)
+target_link_libraries(sycl_cpu.out PRIVATE ${pybind_link} -fsycl)
 
 add_executable(sycl_gpu.out ../main.cpp)
 target_include_directories(sycl_gpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
@@ -19,4 +18,4 @@ target_include_directories(sycl_gpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_gpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
 											-DALPAKA_SYCL_ONEAPI_GPU
 											-fsycl)
-target_link_libraries(sycl_gpu.out PRIVATE pybind11::embed -fsycl)
+target_link_libraries(sycl_gpu.out PRIVATE ${pybind_link} -fsycl)

--- a/benchmark/dataset_size/sycl/pybind11
+++ b/benchmark/dataset_size/sycl/pybind11
@@ -1,1 +1,0 @@
-../../../extern/pybind11/


### PR DESCRIPTION
Use pybind11 to produce plots of benchmark results only if it's installed globally on the machine.