### PR TITLE
Use `std::array` for allocating coordinates in kernels

### DIFF
--- a/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
@@ -131,7 +131,8 @@ namespace clue {
       return remainder;
     }
 
-    ALPAKA_FN_ACC inline float distance(const float* coord_i, const float* coord_j) {
+    ALPAKA_FN_ACC inline float distance(const std::array<float, Ndim>& coord_i,
+                                        const std::array<float, Ndim>& coord_j) {
       float dist_sq = 0.f;
       for (int dim = 0; dim != Ndim; ++dim) {
         if (wrapping[dim])


### PR DESCRIPTION
Since most methods of `std::array` are constexpr, it can be used in device code as well without needing to use raw pointers.