### PR TITLE
Use `fmt::format` instead of `std::format` in tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Boost 1.75.0 REQUIRED)
 
 include(FetchContent)
 
+# alpaka
 FetchContent_Declare(
   alpaka
   GIT_REPOSITORY https://github.com/alpaka-group/alpaka.git
@@ -24,8 +25,7 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS)
 FetchContent_MakeAvailable(alpaka)
 
-include(FetchContent)
-# Get doctest
+# doctest
 FetchContent_Declare(
   doctest
   GIT_REPOSITORY https://github.com/doctest/doctest.git
@@ -34,6 +34,14 @@ FetchContent_GetProperties(doctest)
 if(NOT doctest_POPULATED)
   FetchContent_MakeAvailable(doctest)
 endif()
+
+# fmt
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG        10.2.1  # or another stable version
+)
+FetchContent_MakeAvailable(fmt)
 
 add_subdirectory(cpu)
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB sources ../*.cpp)
 
 add_executable(serial.out ${sources})
+target_link_libraries(serial.out PRIVATE fmt::fmt)
 target_include_directories(
   serial.out
   PRIVATE ${CMAKE_SURCE_DIR}../../include/CLUEstering
@@ -17,7 +18,7 @@ if(TBB_FOUND)
     PRIVATE ${CMAKE_SURCE_DIR}../../include/CLUEstering
             ${doctest_SOURCE_DIR}/doctest ${alpaka_SOURCE_DIR}/include
             ${Boost_INCLUDE_DIR})
-  target_link_libraries(tbb.out PRIVATE TBB::tbb)
+  target_link_libraries(tbb.out PRIVATE TBB::tbb fmt::fmt)
   target_compile_definitions(tbb.out PRIVATE ALPAKA_HOST_ONLY
                                              ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
 endif()
@@ -31,7 +32,7 @@ if(OpenMP_CXX_FOUND)
     PRIVATE ${CMAKE_SURCE_DIR}../../include/CLUEstering
             ${doctest_SOURCE_DIR}/doctest ${alpaka_SOURCE_DIR}/include
             ${Boost_INCLUDE_DIR})
-  target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX fmt::fmt)
   target_compile_definitions(
     openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
 endif()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -12,6 +12,7 @@ foreach(src IN LISTS sources)
   set_source_files_properties(${src} PROPERTIES LANGUAGE CUDA)
 endforeach()
 add_executable(cuda.out ${sources})
+target_link_libraries(cuda.out PRIVATE fmt::fmt)
 target_include_directories(
   cuda.out
   PRIVATE ${CMAKE_SURCE_DIR}../../include/CLUEstering

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -4,7 +4,6 @@
 #include "utility/validation.hpp"
 
 #include <cmath>
-#include <format>
 #include <ranges>
 #include <span>
 #include <vector>

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -4,10 +4,11 @@
 #include "utility/validation.hpp"
 
 #include <cmath>
-#include <format>
 #include <ranges>
 #include <span>
 #include <vector>
+
+#include <fmt/core.h>
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
@@ -16,7 +17,7 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE;
 
 TEST_CASE("Test clustering on benchmarking datasets") {
   for (auto i = 10; i < 19; ++i) {
-    auto coords = read_csv<float, 2>(std::format("../data/data_{}.csv", std::pow(2, i)));
+    auto coords = read_csv<float, 2>(fmt::format("../data/data_{}.csv", std::pow(2, i)));
     const uint32_t n_points = coords.size() / 3;
     std::vector<int> results(2 * n_points);
 
@@ -35,7 +36,7 @@ TEST_CASE("Test clustering on benchmarking datasets") {
     auto isSeed = std::span<const int>(results.data() + n_points, n_points);
 
     const auto truth_data =
-        read_output<2>(std::format("../data/truth_files/data_{}_truth.csv", std::pow(2, i)));
+        read_output<2>(fmt::format("../data/truth_files/data_{}_truth.csv", std::pow(2, i)));
     auto truth_ids = std::span<const int>{truth_data.data(), n_points};
     auto truth_isSeed = std::span<const int>{truth_data.data() + n_points, n_points};
     CHECK(clue::validate_results(clusters, truth_ids));


### PR DESCRIPTION
In order to maintain retro-compatibility when testing on machine with older compiler versions, for now we should use `fmt::format` instead of `std::format`. 