### PR TITLE
Define `make_array` utility in `nostd` namespace

### DIFF
--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -11,6 +11,7 @@
 #include "CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp"
 #include "CLUEstering/DataFormats/alpaka/AlpakaVecArray.hpp"
 #include "CLUEstering/DataFormats/alpaka/SearchBox.hpp"
+#include "CLUEstering/detail/make_array.hpp"
 #include "ConvolutionalKernel.hpp"
 
 using clue::PointsView;
@@ -98,7 +99,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
         // Get the extremes of the search box
         clue::SearchBoxExtremes<Ndim> searchbox_extremes;
         for (int dim{}; dim != Ndim; ++dim) {
-          searchbox_extremes[dim] = {coords_i[dim] - dc, coords_i[dim] + dc};
+          searchbox_extremes[dim] = clue::nostd::make_array(coords_i[dim] - dc, coords_i[dim] + dc);
         }
 
         // Calculate the search box
@@ -193,7 +194,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
         // Get the extremes of the search box
         clue::SearchBoxExtremes<Ndim> searchbox_extremes;
         for (int dim{}; dim != Ndim; ++dim) {
-          searchbox_extremes[dim] = {coords_i[dim] - dm, coords_i[dim] + dm};
+          searchbox_extremes[dim] = clue::nostd::make_array(coords_i[dim] - dm, coords_i[dim] + dm);
         }
 
         // Calculate the search box

--- a/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
@@ -8,6 +8,7 @@
 #include "CLUEstering/DataFormats/alpaka/AlpakaVecArray.hpp"
 #include "CLUEstering/DataFormats/alpaka/AssociationMap.hpp"
 #include "CLUEstering/DataFormats/alpaka/SearchBox.hpp"
+#include "CLUEstering/detail/make_array.hpp"
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/alpaka.hpp>
@@ -106,7 +107,8 @@ namespace clue {
         if (wrapping[dim] and infBin > supBin)
           supBin += nperdim;
 
-        searchbox_bins[dim] = {static_cast<uint32_t>(infBin), static_cast<uint32_t>(supBin)};
+        searchbox_bins[dim] =
+            nostd::make_array(static_cast<uint32_t>(infBin), static_cast<uint32_t>(supBin));
       }
     }
 

--- a/include/CLUEstering/detail/make_array.hpp
+++ b/include/CLUEstering/detail/make_array.hpp
@@ -1,0 +1,16 @@
+
+#pragma once
+
+#include <array>
+#include <type_traits>
+
+namespace clue {
+  namespace nostd {
+
+    template <typename... Tn>
+    inline constexpr auto make_array(Tn&&... args) {
+      return std::array<std::common_type_t<Tn...>, sizeof...(Tn)>{std::forward<Tn>(args)...};
+    }
+
+  }  // namespace nostd
+}  // namespace clue


### PR DESCRIPTION
In some configuration the assignment of arrays to search boxes with brace initalizations caused compilation errors. This PR fixes this.