### PR TITLE
Implement data generators for benchmarks of dataset size

### DIFF
--- a/benchmark/dataset_size/cpu/CMakeLists.txt
+++ b/benchmark/dataset_size/cpu/CMakeLists.txt
@@ -1,9 +1,9 @@
-
 # CPU Serial
 add_executable(serial.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
-  serial.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-                     ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  serial.out
+  PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_link_libraries(serial.out PRIVATE ${pybind_link})
 target_compile_definitions(
   serial.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
@@ -13,8 +13,10 @@ find_package(TBB)
 if(TBB_FOUND)
   add_executable(tbb.out ${CMAKE_SOURCE_DIR}/main.cpp)
   target_include_directories(
-    tbb.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-                    ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+    tbb.out
+    PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+            ${CMAKE_SOURCE_DIR}/../../benchmark ${alpaka_SOURCE_DIR}/include
+            ${Boost_INCLUDE_DIR})
   target_link_libraries(tbb.out PRIVATE ${pybind_link} TBB::tbb)
   target_compile_definitions(tbb.out PRIVATE ALPAKA_HOST_ONLY
                                              ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
@@ -25,13 +27,14 @@ find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
   add_executable(openmp.out ${CMAKE_SOURCE_DIR}/main.cpp)
   target_include_directories(
-    openmp.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+    openmp.out
+    PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+            ${CMAKE_SOURCE_DIR}/../../benchmark ${alpaka_SOURCE_DIR}/include
+            ${Boost_INCLUDE_DIR})
   target_link_libraries(openmp.out PRIVATE ${pybind_link} OpenMP::OpenMP_CXX)
   target_compile_definitions(
     openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
-  set_target_properties(
-	openmp.out PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-							
-endif()
+  set_target_properties(openmp.out PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                              ${CMAKE_BINARY_DIR})
 
+endif()

--- a/benchmark/dataset_size/cuda/CMakeLists.txt
+++ b/benchmark/dataset_size/cuda/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 enable_language(CUDA)
 set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CUDA_COMPILER})
 
@@ -7,14 +6,16 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 endif()
 
-set_source_files_properties(${CMAKE_SOURCE_DIR}/main.cpp PROPERTIES LANGUAGE CUDA)
+set_source_files_properties(${CMAKE_SOURCE_DIR}/main.cpp PROPERTIES LANGUAGE
+                                                                    CUDA)
 add_executable(cuda.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
-  cuda.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-				   ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  cuda.out
+  PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_link_libraries(cuda.out PRIVATE ${pybind_link})
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
-set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON
-										  CUDA_ARCHITECTURES "50;60;61;62;70;80;90")
-
+set_target_properties(
+  cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
+                                                    "50;60;61;62;70;80;90")

--- a/benchmark/dataset_size/sycl/CMakeLists.txt
+++ b/benchmark/dataset_size/sycl/CMakeLists.txt
@@ -1,21 +1,20 @@
-
 set(CMAKE_CXX_COMPILER ${SYCL_COMPILER})
 add_executable(sycl_cpu.out ../main.cpp)
-target_include_directories(sycl_cpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-												${alpaka_SOURCE_DIR}/include
-												${Boost_INCLUDE_DIR})
+target_include_directories(
+  sycl_cpu.out
+  PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_cpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_cpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
-											-DALPAKA_SYCL_ONEAPI_CPU
-											-fsycl)
+                                            -DALPAKA_SYCL_ONEAPI_CPU -fsycl)
 target_link_libraries(sycl_cpu.out PRIVATE ${pybind_link} -fsycl)
 
 add_executable(sycl_gpu.out ../main.cpp)
-target_include_directories(sycl_gpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-												${alpaka_SOURCE_DIR}/include
-												${Boost_INCLUDE_DIR})
+target_include_directories(
+  sycl_gpu.out
+  PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_gpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_gpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
-											-DALPAKA_SYCL_ONEAPI_GPU
-											-fsycl)
+                                            -DALPAKA_SYCL_ONEAPI_GPU -fsycl)
 target_link_libraries(sycl_gpu.out PRIVATE ${pybind_link} -fsycl)

--- a/benchmark/utils/generation.hpp
+++ b/benchmark/utils/generation.hpp
@@ -1,0 +1,92 @@
+
+#include <algorithm>
+#include <execution>
+#include <random>
+#include <vector>
+
+#include "CLUEstering/DataFormats/PointsHost.hpp"
+
+namespace clue {
+  namespace utils {
+
+    template <uint8_t Ndim>
+    using ClusterCenters = std::vector<std::array<float, Ndim>>;
+
+    namespace detail {
+
+      template <uint8_t Ndim>
+      ClusterCenters<Ndim> computeClusterCenters(size_t n_clusters,
+                                                 std::uniform_real_distribution<float> uniform_dist,
+                                                 std::mt19937& gen) {
+        ClusterCenters<Ndim> cluster_centers(n_clusters);
+
+        std::generate(cluster_centers.begin(), cluster_centers.end(), [&]() {
+          std::array<float, Ndim> center;
+          std::generate(std::execution::unseq, center.begin(), center.end(), [&]() {
+            return uniform_dist(gen);
+          });
+          return center;
+        });
+
+        return cluster_centers;
+      }
+
+      template <uint8_t Ndim>
+      void generateClusterData(clue::PointsHost<Ndim>& points,
+                               const ClusterCenters<Ndim>& cluster_centers,
+                               size_t n_clusters,
+                               size_t cluster_size,
+                               float stddev,
+                               std::mt19937& gen) {
+        for (auto cluster = 0u; cluster < n_clusters; ++cluster) {
+          for (auto dim = 0u; dim < Ndim; ++dim) {
+            std::normal_distribution<float> gaussian_dist(cluster_centers[cluster][dim], stddev);
+            std::generate_n(std::execution::unseq,
+                            points.coords(dim).begin() + cluster * cluster_size,
+                            cluster_size,
+                            [&]() { return gaussian_dist(gen); });
+          }
+        }
+      }
+
+      template <uint8_t Ndim>
+      void generateNoiseData(clue::PointsHost<Ndim>& points,
+                             size_t data_size,
+                             size_t noise_size,
+                             std::uniform_real_distribution<float> uniform_dist,
+                             std::mt19937& gen) {
+        for (auto dim = 0u; dim < Ndim; ++dim) {
+          std::generate_n(
+              std::execution::unseq, points.coords(dim).begin() + data_size, noise_size, [&]() {
+                return uniform_dist(gen);
+              });
+        }
+      }
+
+    }  // namespace detail
+
+    template <uint8_t Ndim>
+    void generateRandomData(clue::PointsHost<Ndim>& points,
+                            size_t n_clusters,
+                            std::pair<float, float> space_boundaries,
+                            float stddev,
+                            float noisiness = .1f,
+                            int seed = 0) {
+      std::mt19937 gen(seed);
+      std::uniform_real_distribution<float> uniform_dist(space_boundaries.first,
+                                                         space_boundaries.second);
+
+      auto cluster_centers = detail::computeClusterCenters<Ndim>(n_clusters, uniform_dist, gen);
+
+      const auto cluster_size =
+          static_cast<size_t>(std::floor(points.size() * (1 - noisiness) / n_clusters));
+      const auto data_size = n_clusters * cluster_size;
+      const auto noise_size = points.size() - data_size;
+      detail::generateClusterData<Ndim>(
+          points, cluster_centers, n_clusters, cluster_size, stddev, gen);
+      detail::generateNoiseData<Ndim>(points, data_size, noise_size, uniform_dist, gen);
+      std::fill(points.weights().begin(), points.weights().end(), 1.0f);
+    }
+
+  }  // namespace utils
+}  // namespace clue


### PR DESCRIPTION
In order to be able to benchmark large dataset sizes without making the repository heavier with large csv files, this PR provides data generators for generating random datasets when executing the benchmarks.
The already existing datasets are still available for testing and profiling (where reproducible results are needed).