### PR TITLE
Remove unneeded use of accelerator object in Tiles methods

### DIFF
--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -56,7 +56,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                                         float dc,
                                         uint32_t point_id) {
     if constexpr (N_ == 0) {
-      auto binId = tiles->getGlobalBinByBin(acc, base_vec);
+      auto binId = tiles->getGlobalBinByBin(base_vec);
       // get the size of this bin
       auto binSize = (*tiles)[binId].size();
 
@@ -105,7 +105,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
         // Calculate the search box
         clue::SearchBoxBins<Ndim> searchbox_bins;
-        dev_tiles->searchBox(acc, searchbox_extremes, searchbox_bins);
+        dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
 
         VecArray<uint32_t, Ndim> base_vec;
         for_recursion<TAcc, Ndim, Ndim>(
@@ -129,7 +129,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
                                                        float dm_sq,
                                                        uint32_t point_id) {
     if constexpr (N_ == 0) {
-      int binId{tiles->getGlobalBinByBin(acc, base_vec)};
+      int binId{tiles->getGlobalBinByBin(base_vec)};
       // get the size of this bin
       int binSize{(*tiles)[binId].size()};
 
@@ -200,7 +200,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
         // Calculate the search box
         clue::SearchBoxBins<Ndim> searchbox_bins;
-        dev_tiles->searchBox(acc, searchbox_extremes, searchbox_bins);
+        dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
 
         VecArray<uint32_t, Ndim> base_vec{};
         for_recursion_nearest_higher<TAcc, Ndim, Ndim>(acc,

--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -69,7 +69,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
         float dist_ij_sq = tiles->distance(coords_i, coords_j);
 
-        auto k = kernel(acc, alpaka::math::sqrt(acc, dist_ij_sq), point_id, j);
+        auto k = kernel(acc, xtd::sqrt(dist_ij_sq), point_id, j);
         *rho_i += (int)(dist_ij_sq <= dc * dc) * k * dev_points->weight[j];
 
       }  // end of interate inside this bin

--- a/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
@@ -27,7 +27,7 @@ namespace clue {
   template <typename TFunc>
   struct KernelComputeAssociations {
     template <typename TAcc>
-      requires std::is_invocable_r_v<uint32_t, TFunc, const TAcc&, size_t>
+      requires std::is_invocable_r_v<uint32_t, TFunc, const TAcc&, uint32_t>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   size_t size,
                                   uint32_t* associations,
@@ -37,7 +37,7 @@ namespace clue {
       }
     }
     template <typename TAcc>
-      requires std::is_invocable_r_v<uint32_t, TFunc, size_t>
+      requires std::is_invocable_r_v<uint32_t, TFunc, uint32_t>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   size_t size,
                                   uint32_t* associations,


### PR DESCRIPTION
Now that we use `xtd` for math operations we can reduce the number of device functions where we pass the accelerator as argument.