### PR TITLE
Rework followers using AssociatonMap

### DIFF
--- a/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
@@ -104,6 +104,11 @@ namespace clue {
     size_t m_nbins;
 
   public:
+    struct Extents {
+      uint32_t content;
+      uint32_t offset;
+    };
+
     AssociationMap() = default;
     // TODO: see above
     AssociationMap(size_t nelements, size_t nbins, const TDev& dev)
@@ -170,6 +175,12 @@ namespace clue {
     }
 
     auto size() const { return m_nbins; }
+
+    auto extents() const {
+      return Extents{
+          alpaka::trait::GetExtents<clue::device_buffer<TDev, uint32_t[]>>{}(m_indexes)[0u],
+          alpaka::trait::GetExtents<clue::device_buffer<TDev, uint32_t[]>>{}(m_offsets)[0u]};
+    }
 
     ALPAKA_FN_HOST const device_buffer<TDev, uint32_t[]>& indexes() const { return m_indexes; }
     ALPAKA_FN_HOST device_buffer<TDev, uint32_t[]>& indexes() { return m_indexes; }

--- a/include/CLUEstering/DataFormats/alpaka/Followers.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/Followers.hpp
@@ -1,0 +1,49 @@
+
+#pragma once
+
+#include "CLUEstering/DataFormats/alpaka/AssociationMap.hpp"
+#include "CLUEstering/detail/concepts.hpp"
+
+namespace clue {
+
+  namespace concepts = detail::concepts;
+
+  class AssociationMapView;
+  template <concepts::device TDev>
+  class AssociationMap;
+
+  template <concepts::device TDev>
+  class Followers {
+  public:
+    Followers(uint32_t npoints, const TDev& dev)
+        : m_assoc(npoints, npoints, dev), m_view{make_device_buffer<AssociationMapView>(dev)} {}
+    template <concepts::queue TQueue>
+    Followers(uint32_t npoints, TQueue queue)
+        : m_assoc(npoints, npoints, queue), m_view{make_device_buffer<AssociationMapView>(queue)} {}
+
+    template <concepts::queue TQueue>
+    ALPAKA_FN_HOST void initialize(uint32_t npoints, TQueue queue) {
+      m_assoc.initialize(npoints, npoints, queue);
+    }
+    template <concepts::queue TQueue>
+    ALPAKA_FN_HOST void reset(uint32_t npoints, TQueue queue) {
+      m_assoc.reset(queue, npoints, npoints);
+    }
+
+    template <concepts::accelerator TAcc, concepts::queue TQueue, uint8_t Ndim>
+    ALPAKA_FN_HOST void fill(TQueue queue, PointsDevice<Ndim, TDev>& d_points) {
+      m_assoc.template fill<TAcc>(d_points.size(), d_points.nearestHigher(), queue);
+    }
+
+    ALPAKA_FN_HOST inline constexpr uint32_t extents() const { return m_assoc.extents().content; }
+
+    ALPAKA_FN_HOST AssociationMapView* view() { return m_assoc.view(); }
+
+  private:
+    AssociationMap<TDev> m_assoc;
+    device_buffer<TDev, AssociationMapView> m_view;
+  };
+
+  using FollowersView = clue::AssociationMapView;
+
+}  // namespace clue


### PR DESCRIPTION
This PR reworks the Followers buffer using an association map. Before the Followers were a buffer of compile-time-sized VecArrays, which implied a big waste of memory and hindered the generality of the code. Now the Followers occupy just 2% of the memory they required before, and are completely built at runtime.
Furthermore, benchmarks show comparable or even better performance:
![image](https://github.com/user-attachments/assets/eb973b90-a066-4af6-8b3b-f040534bd7e2)
