### PR TITLE
Pass alpaka Queues by reference

### DIFF
--- a/include/CLUEstering/AlpakaCore/CachingAllocator.hpp
+++ b/include/CLUEstering/AlpakaCore/CachingAllocator.hpp
@@ -162,7 +162,7 @@ namespace clue {
     }
 
     // Allocate given number of bytes on the current device associated to given queue
-    void* allocate(size_t bytes, Queue queue) {
+    void* allocate(size_t bytes, Queue& queue) {
       // create a block descriptor for the requested allocation
       BlockDescriptor block;
       block.queue = std::move(queue);

--- a/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/CLUE/CLUEAlpakaKernels.hpp
@@ -230,7 +230,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
 
         // Determine whether the point is a seed or an outlier
         bool is_seed{(delta_i > seed_dc) && (rho_i >= rhoc)};
-        bool is_outlier{(delta_i > dm) && (rho_i < rhoc)};
 
         if (is_seed) {
           dev_points->is_seed[i] = 1;

--- a/include/CLUEstering/DataFormats/Common.hpp
+++ b/include/CLUEstering/DataFormats/Common.hpp
@@ -37,7 +37,7 @@ namespace clue {
   uint32_t computeAlignSoASize(uint32_t n_points);
 
   template <concepts::queue TQueue, uint8_t Ndim, concepts::device TDev>
-  void copyToHost(TQueue queue,
+  void copyToHost(TQueue& queue,
                   PointsHost<Ndim>& h_points,
                   const PointsDevice<Ndim, TDev>& d_points) {
     alpaka::memcpy(queue,
@@ -50,7 +50,7 @@ namespace clue {
         make_device_view(alpaka::getDev(queue), d_points.m_hostView->is_seed, h_points.size()));
   }
   template <concepts::queue TQueue, uint8_t Ndim, concepts::device TDev>
-  void copyToDevice(TQueue queue,
+  void copyToDevice(TQueue& queue,
                     PointsDevice<Ndim, TDev>& d_points,
                     const PointsHost<Ndim>& h_points) {
     alpaka::memcpy(queue,

--- a/include/CLUEstering/DataFormats/PointsDevice.hpp
+++ b/include/CLUEstering/DataFormats/PointsDevice.hpp
@@ -88,7 +88,7 @@ namespace clue {
   class PointsDevice {
   public:
     template <concepts::queue TQueue>
-    PointsDevice(TQueue queue, uint32_t n_points)
+    PointsDevice(TQueue& queue, uint32_t n_points)
         : m_buffer{make_device_buffer<std::byte[]>(queue,
                                                    soa::device::computeSoASize<Ndim>(n_points))},
           m_view{make_device_buffer<PointsView>(queue)},
@@ -99,7 +99,7 @@ namespace clue {
     }
 
     template <concepts::queue TQueue>
-    PointsDevice(TQueue queue, uint32_t n_points, std::span<std::byte> buffer)
+    PointsDevice(TQueue& queue, uint32_t n_points, std::span<std::byte> buffer)
         : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
           m_view{make_device_buffer<PointsView>(queue)},
           m_hostView{make_host_buffer<PointsView>(queue)},
@@ -113,7 +113,7 @@ namespace clue {
 
     template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsDevice(TQueue queue, uint32_t n_points, TBuffers... buffers)
+    PointsDevice(TQueue& queue, uint32_t n_points, TBuffers... buffers)
         : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
           m_view{make_device_buffer<PointsView>(queue)},
           m_hostView{make_host_buffer<PointsView>(queue)},
@@ -177,11 +177,11 @@ namespace clue {
     ALPAKA_FN_HOST const PointsView* view() const { return m_view.data(); }
 
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
-    friend void copyToHost(_TQueue queue,
+    friend void copyToHost(_TQueue& queue,
                            PointsHost<_Ndim>& h_points,
                            const PointsDevice<_Ndim, _TDev>& d_points);
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
-    friend void copyToDevice(_TQueue queue,
+    friend void copyToDevice(_TQueue& queue,
                              PointsDevice<_Ndim, _TDev>& d_points,
                              const PointsHost<_Ndim>& h_points);
 

--- a/include/CLUEstering/DataFormats/PointsHost.hpp
+++ b/include/CLUEstering/DataFormats/PointsHost.hpp
@@ -82,7 +82,7 @@ namespace clue {
   class PointsHost {
   public:
     template <concepts::queue TQueue>
-    PointsHost(TQueue queue, uint32_t n_points)
+    PointsHost(TQueue& queue, uint32_t n_points)
         : m_buffer{make_host_buffer<std::byte[]>(queue, soa::host::computeSoASize<Ndim>(n_points))},
           m_view{make_host_buffer<PointsView>(queue)},
           m_size{n_points} {
@@ -90,7 +90,7 @@ namespace clue {
     }
 
     template <concepts::queue TQueue>
-    PointsHost(TQueue queue, uint32_t n_points, std::span<std::byte> buffer)
+    PointsHost(TQueue& queue, uint32_t n_points, std::span<std::byte> buffer)
         : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
       assert(buffer.size() == soa::host::computeSoASize<Ndim>(n_points));
 
@@ -99,7 +99,7 @@ namespace clue {
 
     template <concepts::queue TQueue, std::ranges::contiguous_range... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsHost(TQueue queue, uint32_t n_points, TBuffers&&... buffers)
+    PointsHost(TQueue& queue, uint32_t n_points, TBuffers&&... buffers)
         : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
       soa::host::partitionSoAView<Ndim>(
           m_view.data(), n_points, std::forward<TBuffers>(buffers)...);
@@ -107,7 +107,7 @@ namespace clue {
 
     template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsHost(TQueue queue, uint32_t n_points, TBuffers... buffers)
+    PointsHost(TQueue& queue, uint32_t n_points, TBuffers... buffers)
         : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
       soa::host::partitionSoAView<Ndim>(m_view.data(), n_points, buffers...);
     }
@@ -161,11 +161,11 @@ namespace clue {
     ALPAKA_FN_HOST const PointsView* view() const { return m_view.data(); }
 
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
-    friend void copyToHost(_TQueue queue,
+    friend void copyToHost(_TQueue& queue,
                            PointsHost<_Ndim>& h_points,
                            const PointsDevice<_Ndim, _TDev>& d_points);
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
-    friend void copyToDevice(_TQueue queue,
+    friend void copyToDevice(_TQueue& queue,
                              PointsDevice<_Ndim, _TDev>& d_points,
                              const PointsHost<_Ndim>& h_points);
 

--- a/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/AssociationMap.hpp
@@ -132,7 +132,7 @@ namespace clue {
     }
 
     template <concepts::queue TQueue>
-    AssociationMap(size_t nelements, size_t nbins, TQueue queue)
+    AssociationMap(size_t nelements, size_t nbins, TQueue& queue)
         : m_indexes{make_device_buffer<uint32_t[]>(queue, nelements)},
           m_offsets{make_device_buffer<uint32_t[]>(queue, nbins + 1)},
           m_hview{make_host_buffer<AssociationMapView>(queue)},
@@ -151,7 +151,7 @@ namespace clue {
     AssociationMapView* view() { return m_view.data(); }
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void initialize(size_t nelements, size_t nbins, TQueue queue) {
+    ALPAKA_FN_HOST void initialize(size_t nelements, size_t nbins, TQueue& queue) {
       m_indexes = make_device_buffer<uint32_t[]>(queue, nelements);
       m_offsets = make_device_buffer<uint32_t[]>(queue, nbins);
       alpaka::memset(queue, m_offsets, 0);
@@ -165,7 +165,7 @@ namespace clue {
     }
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void reset(TQueue queue, uint32_t nelements, int32_t nbins) {
+    ALPAKA_FN_HOST void reset(TQueue& queue, uint32_t nelements, int32_t nbins) {
       alpaka::memset(queue, m_indexes, 0);
       alpaka::memset(queue, m_offsets, 0);
       m_nbins = nbins;
@@ -210,7 +210,7 @@ namespace clue {
     ALPAKA_FN_ACC uint32_t offsets(size_t bin_id) const { return m_offsets[bin_id]; }
 
     template <concepts::accelerator TAcc, typename TFunc, concepts::queue TQueue>
-    ALPAKA_FN_HOST void fill(size_t size, TFunc func, TQueue queue) {
+    ALPAKA_FN_HOST void fill(size_t size, TFunc func, TQueue& queue) {
       auto bin_buffer = make_device_buffer<uint32_t[]>(queue, size);
 
       // compute associations
@@ -264,7 +264,7 @@ namespace clue {
     }
 
     template <concepts::accelerator TAcc, concepts::queue TQueue>
-    ALPAKA_FN_HOST void fill(size_t size, std::span<int> associations, TQueue queue) {
+    ALPAKA_FN_HOST void fill(size_t size, std::span<int> associations, TQueue& queue) {
       const auto blocksize = 512;
       const auto gridsize = divide_up_by(size, blocksize);
       const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);

--- a/include/CLUEstering/DataFormats/alpaka/Followers.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/Followers.hpp
@@ -18,20 +18,20 @@ namespace clue {
     Followers(uint32_t npoints, const TDev& dev)
         : m_assoc(npoints, npoints, dev), m_view{make_device_buffer<AssociationMapView>(dev)} {}
     template <concepts::queue TQueue>
-    Followers(uint32_t npoints, TQueue queue)
+    Followers(uint32_t npoints, TQueue& queue)
         : m_assoc(npoints, npoints, queue), m_view{make_device_buffer<AssociationMapView>(queue)} {}
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void initialize(uint32_t npoints, TQueue queue) {
+    ALPAKA_FN_HOST void initialize(uint32_t npoints, TQueue& queue) {
       m_assoc.initialize(npoints, npoints, queue);
     }
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void reset(uint32_t npoints, TQueue queue) {
+    ALPAKA_FN_HOST void reset(uint32_t npoints, TQueue& queue) {
       m_assoc.reset(queue, npoints, npoints);
     }
 
     template <concepts::accelerator TAcc, concepts::queue TQueue, uint8_t Ndim>
-    ALPAKA_FN_HOST void fill(TQueue queue, PointsDevice<Ndim, TDev>& d_points) {
+    ALPAKA_FN_HOST void fill(TQueue& queue, PointsDevice<Ndim, TDev>& d_points) {
       m_assoc.template fill<TAcc>(d_points.size(), d_points.nearestHigher(), queue);
     }
 

--- a/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
+++ b/include/CLUEstering/DataFormats/alpaka/TilesAlpaka.hpp
@@ -143,7 +143,7 @@ namespace clue {
   class TilesAlpaka {
   public:
     template <concepts::queue TQueue>
-    TilesAlpaka(TQueue queue, uint32_t n_points, uint32_t pointsPerTile) {
+    TilesAlpaka(TQueue& queue, uint32_t n_points, uint32_t pointsPerTile) {
       auto n_tiles = static_cast<int32_t>(std::ceil(n_points / static_cast<float>(pointsPerTile)));
       const auto n_perdim = static_cast<int32_t>(std::ceil(std::pow(n_tiles, 1. / Ndim)));
       n_tiles = static_cast<int32_t>(std::pow(n_perdim, Ndim));
@@ -169,7 +169,7 @@ namespace clue {
       alpaka::memcpy(queue, m_view, host_view);
     }
     template <concepts::queue TQueue>
-    TilesAlpaka(TQueue queue, uint32_t n_points, int32_t n_tiles)
+    TilesAlpaka(TQueue& queue, uint32_t n_points, int32_t n_tiles)
         : m_assoc{clue::AssociationMap<TDev>(n_points, n_tiles, queue)},
           m_minmax{clue::make_device_buffer<CoordinateExtremes<Ndim>>(queue)},
           m_tilesizes{clue::make_device_buffer<float[Ndim]>(queue)},
@@ -193,7 +193,10 @@ namespace clue {
     TilesAlpakaView<Ndim>* view() { return m_view.data(); }
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void initialize(uint32_t npoints, int32_t ntiles, int32_t nperdim, TQueue queue) {
+    ALPAKA_FN_HOST void initialize(uint32_t npoints,
+                                   int32_t ntiles,
+                                   int32_t nperdim,
+                                   TQueue& queue) {
       m_assoc.initialize(npoints, ntiles, queue);
       m_ntiles = ntiles;
       m_nperdim = nperdim;
@@ -211,7 +214,7 @@ namespace clue {
     }
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void reset(uint32_t npoints, int32_t ntiles, int32_t nperdim, TQueue queue) {
+    ALPAKA_FN_HOST void reset(uint32_t npoints, int32_t ntiles, int32_t nperdim, TQueue& queue) {
       m_assoc.reset(queue, npoints, ntiles);
 
       m_ntiles = ntiles;
@@ -244,7 +247,7 @@ namespace clue {
     };
 
     template <concepts::accelerator TAcc, concepts::queue TQueue>
-    ALPAKA_FN_HOST void fill(TQueue queue, PointsDevice<Ndim, TDev>& d_points, size_t size) {
+    ALPAKA_FN_HOST void fill(TQueue& queue, PointsDevice<Ndim, TDev>& d_points, size_t size) {
       auto dev = alpaka::getDev(queue);
       auto pointsView = d_points.view();
       m_assoc.template fill<TAcc>(size, GetGlobalBin{pointsView, m_view.data()}, queue);


### PR DESCRIPTION
To reduce the (although small) overhead due to excessive reference-counting and creation-destruction of the underlying streams, from now on alpaka Queues are passed by reference.