### PR TITLE
Compile internal `math` functions only inside device code

### DIFF
--- a/include/CLUEstering/internal/math/defines.hpp
+++ b/include/CLUEstering/internal/math/defines.hpp
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#if defined(__CUDA_ARCH__)
+#define CUDA_DEVICE_FN
+#elif defined(__HIP_DEVICE_COMPILE__)
+#define HIP_DEVICE_FN
+#elif defined(__SYCL_DEVICE_ONLY__)
+#define SYCL_DEVICE_FN
+#endif

--- a/include/CLUEstering/internal/math/exp/exp.hpp
+++ b/include/CLUEstering/internal/math/exp/exp.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "CLUEstering/internal/math/defines.hpp"
 #include <concepts>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
@@ -13,13 +14,13 @@ namespace clue {
     namespace math {
 
       ALPAKA_FN_ACC inline constexpr float exp(float x) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::exp(x);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::exp(x);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::exp(x);
 #else
@@ -29,13 +30,13 @@ namespace clue {
       }
 
       ALPAKA_FN_ACC inline constexpr double exp(double x) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::exp(x);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::exp(x);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::exp(x);
 #else

--- a/include/CLUEstering/internal/math/max/max.hpp
+++ b/include/CLUEstering/internal/math/max/max.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "CLUEstering/detail/concepts.hpp"
+#include "CLUEstering/internal/math/defines.hpp"
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -14,13 +15,13 @@ namespace clue {
 
       template <clue::detail::concepts::Numeric T>
       ALPAKA_FN_ACC inline constexpr T max(const T& a, const T& b) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::max(a, b);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::max(a, b);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::max(a, b);
 #else
@@ -31,13 +32,13 @@ namespace clue {
 
       template <clue::detail::concepts::Numeric T, typename Compare>
       ALPAKA_FN_ACC inline constexpr T max(const T& a, const T& b, Compare comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::max(a, b, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::max(a, b, comp);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::max(a, b, comp);
 #else

--- a/include/CLUEstering/internal/math/min/min.hpp
+++ b/include/CLUEstering/internal/math/min/min.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "CLUEstering/detail/concepts.hpp"
+#include "CLUEstering/internal/math/defines.hpp"
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -14,13 +15,13 @@ namespace clue {
 
       template <clue::detail::concepts::Numeric T>
       ALPAKA_FN_ACC inline constexpr T min(const T& a, const T& b) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::min(a, b);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::min(a, b);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::min(a, b);
 #else
@@ -31,13 +32,13 @@ namespace clue {
 
       template <clue::detail::concepts::Numeric T, typename Compare>
       ALPAKA_FN_ACC inline constexpr T min(const T& a, const T& b, Compare comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::min(a, b, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::min(a, b, comp);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::min(a, b, comp);
 #else

--- a/include/CLUEstering/internal/math/pow/pow.hpp
+++ b/include/CLUEstering/internal/math/pow/pow.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "CLUEstering/internal/math/defines.hpp"
+
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)
 #include <cmath>
@@ -11,13 +13,13 @@ namespace clue {
     namespace math {
 
       ALPAKA_FN_ACC inline constexpr float pow(float base, float exp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::pow(base, exp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::pow(base, exp);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::pow(base, exp);
 #else
@@ -27,13 +29,13 @@ namespace clue {
       }
 
       ALPAKA_FN_ACC inline constexpr double pow(double base, double exp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::pow(base, exp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::pow(base, exp);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::pow(base, exp);
 #else

--- a/include/CLUEstering/internal/math/sqrt/sqrt.hpp
+++ b/include/CLUEstering/internal/math/sqrt/sqrt.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "CLUEstering/internal/math/defines.hpp"
 #include <concepts>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
@@ -13,13 +14,13 @@ namespace clue {
     namespace math {
 
       ALPAKA_FN_ACC inline constexpr float sqrt(float x) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::sqrt(x);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::sqrt(x);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::sqrt(x);
 #else
@@ -29,13 +30,13 @@ namespace clue {
       }
 
       ALPAKA_FN_ACC inline constexpr double sqrt(double x) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(CUDA_DEVICE_FN)
         // CUDA device code
         return ::sqrt(x);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(HIP_DEVICE_FN)
         // HIP/ROCm device code
         return ::sqrt(x);
-#elif defined(ALPAKA_ACC_SYCL_ENABLED)
+#elif defined(SYCL_DEVICE_FN)
         // SYCL device code
         return sycl::sqrt(x);
 #else


### PR DESCRIPTION
This PR uses backend specific macros to only compile the functions in `internal/math` when they are called inside device code.