### PR TITLE
Remove alpaka accelerator namespace and move definitions in `clue::internal`

### DIFF
--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -4,10 +4,6 @@
 #include <vector>
 #include "CLUEstering/CLUEstering.hpp"
 
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Acc1D;
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Device;
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Queue;
-
 template <uint8_t Ndim, typename Kernel>
 void run(float dc,
          float rhoc,
@@ -17,13 +13,13 @@ void run(float dc,
          std::tuple<float*, int*>&& pData,
          int32_t n_points,
          const Kernel& kernel,
-         Queue queue,
+         clue::Queue queue,
          size_t block_size) {
   clue::Clusterer<Ndim> algo(queue, dc, rhoc, dm, seed_dc, pPBin);
 
   // Create the host and device points
   clue::PointsHost<Ndim> h_points(queue, n_points, std::get<0>(pData), std::get<1>(pData));
-  clue::PointsDevice<Ndim, Device> d_points(queue, n_points);
+  clue::PointsDevice<Ndim, clue::Device> d_points(queue, n_points);
 
   algo.make_clusters(h_points, d_points, kernel, queue, block_size);
 }

--- a/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
+++ b/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
@@ -12,9 +12,10 @@
 namespace py = pybind11;
 
 namespace alpaka_cuda_async {
+
   void listDevices(const std::string& backend) {
     const char tab = '\t';
-    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
       std::cout << "No devices found for the " << backend << " backend." << std::endl;
       return;
@@ -44,10 +45,10 @@ namespace alpaka_cuda_async {
     auto rResults = results.request();
     int* pResults = static_cast<int*>(rResults.ptr);
 
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, device_id);
 
     // Create the queue
-    Queue queue(dev_acc);
+    clue::Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {

--- a/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
+++ b/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
@@ -15,7 +15,7 @@ namespace alpaka_rocm_async {
 
   void listDevices(const std::string& backend) {
     const char tab = '\t';
-    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
       std::cout << "No devices found for the " << backend << " backend." << std::endl;
       return;
@@ -45,10 +45,10 @@ namespace alpaka_rocm_async {
     auto rResults = results.request();
     int* pResults = static_cast<int*>(rResults.ptr);
 
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, device_id);
 
     // Create the queue
-    Queue queue(dev_acc);
+    clue::Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {

--- a/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
@@ -15,14 +15,14 @@ namespace alpaka_omp2_async {
 
   void listDevices(const std::string& backend) {
     const char tab = '\t';
-    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
       std::cout << "No devices found for the " << backend << " backend." << std::endl;
       return;
     } else {
       std::cout << backend << " devices found: \n";
       for (size_t i{}; i < devices.size(); ++i) {
-        std::cout << tab << "Device " << i << ": " << alpaka::getName(devices[i]) << '\n';
+        std::cout << tab << "device " << i << ": " << alpaka::getName(devices[i]) << '\n';
       }
     }
   }
@@ -45,10 +45,10 @@ namespace alpaka_omp2_async {
     auto rResults = results.request();
     int* pResults = static_cast<int*>(rResults.ptr);
 
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, device_id);
 
     // Create the queue
-    Queue queue(dev_acc);
+    clue::Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {

--- a/CLUEstering/BindingModules/serial/binding_cpu.cpp
+++ b/CLUEstering/BindingModules/serial/binding_cpu.cpp
@@ -16,7 +16,7 @@ namespace alpaka_serial_sync {
 
   void listDevices(const std::string& backend) {
     const char tab = '\t';
-    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
       std::cout << "No devices found for the " << backend << " backend." << std::endl;
       return;
@@ -46,10 +46,10 @@ namespace alpaka_serial_sync {
     auto rResults = results.request();
     int* pResults = static_cast<int*>(rResults.ptr);
 
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, device_id);
 
     // Create the queue
-    Queue queue(dev_acc);
+    clue::Queue queue(dev_acc);
 
     // Running the clustering algorithm
     switch (Ndim) {

--- a/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
+++ b/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
@@ -15,14 +15,14 @@ namespace alpaka_tbb_async {
 
   void listDevices(const std::string& backend) {
     const char tab = '\t';
-    const std::vector<Device> devices = alpaka::getDevs(alpaka::Platform<Acc1D>());
+    const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
       std::cout << "No devices found for the " << backend << " backend." << std::endl;
       return;
     } else {
       std::cout << backend << " devices found: \n";
       for (size_t i{}; i < devices.size(); ++i) {
-        std::cout << tab << "Device " << i << ": " << alpaka::getName(devices[i]) << '\n';
+        std::cout << tab << "device " << i << ": " << alpaka::getName(devices[i]) << '\n';
       }
     }
   }
@@ -45,10 +45,10 @@ namespace alpaka_tbb_async {
     auto rResults = results.request();
     int* pResults = static_cast<int*>(rResults.ptr);
 
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, device_id);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, device_id);
 
     // Create the queue
-    Queue queue(dev_acc);
+    clue::Queue queue(dev_acc);
 
     // Running the clustering algorithm //
     switch (Ndim) {

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -7,16 +7,12 @@
 
 #include "CLUEstering/CLUEstering.hpp"
 
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Acc1D;
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Device;
-using ALPAKA_ACCELERATOR_NAMESPACE_CLUE::Queue;
-
 void run(const std::string& input_file) {
-  const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(dev_acc);
+  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(dev_acc);
 
   auto h_points = clue::read_csv<2>(queue, input_file);
-  clue::PointsDevice<2, Device> d_points(queue, h_points.size());
+  clue::PointsDevice<2, clue::Device> d_points(queue, h_points.size());
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "CLUEstering/core/Clusterer.hpp"
+#include "CLUEstering/core/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/alpaka/TilesAlpaka.hpp"

--- a/include/CLUEstering/core/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/core/CLUEAlpakaKernels.hpp
@@ -16,267 +16,272 @@
 #include <chrono>
 #include <cstdint>
 
-using clue::PointsView;
-using clue::TilesAlpakaView;
-using clue::VecArray;
+namespace clue {
+  namespace internal {
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE {
+    using clue::PointsView;
+    using clue::TilesAlpakaView;
+    using clue::VecArray;
 
-  constexpr int32_t reserve{1000000};
+    constexpr int32_t reserve{1000000};
 
-  template <uint8_t Ndim>
-  ALPAKA_FN_ACC std::array<float, Ndim> getCoords(PointsView* d_points, int32_t i) {
-    std::array<float, Ndim> coords;
-    for (auto dim = 0; dim < Ndim; ++dim) {
-      coords[dim] = d_points->coords[i + dim * d_points->n];
-    }
-
-    return coords;
-  }
-
-  template <typename TAcc, uint8_t Ndim, uint8_t N_, typename KernelType>
-  ALPAKA_FN_HOST_ACC void for_recursion(const TAcc& acc,
-                                        VecArray<int32_t, Ndim>& base_vec,
-                                        const clue::SearchBoxBins<Ndim>& search_box,
-                                        TilesAlpakaView<Ndim>* tiles,
-                                        PointsView* dev_points,
-                                        const KernelType& kernel,
-                                        const std::array<float, Ndim>& coords_i,
-                                        float* rho_i,
-                                        float dc,
-                                        int32_t point_id) {
-    if constexpr (N_ == 0) {
-      auto binId = tiles->getGlobalBinByBin(base_vec);
-      // get the size of this bin
-      auto binSize = (*tiles)[binId].size();
-
-      // iterate inside this bin
-      for (int binIter{}; binIter < binSize; ++binIter) {
-        int32_t j{(*tiles)[binId][binIter]};
-        // query N_{dc_}(i)
-
-        auto coords_j = getCoords<Ndim>(dev_points, j);
-
-        float dist_ij_sq = tiles->distance(coords_i, coords_j);
-
-        auto k = kernel(acc, clue::internal::math::sqrt(dist_ij_sq), point_id, j);
-        *rho_i += (int)(dist_ij_sq <= dc * dc) * k * dev_points->weight[j];
-
-      }  // end of interate inside this bin
-      return;
-    } else {
-      for (auto i = search_box[search_box.size() - N_][0];
-           i <= search_box[search_box.size() - N_][1];
-           ++i) {
-        base_vec[base_vec.capacity() - N_] = i;
-        for_recursion<TAcc, Ndim, N_ - 1>(
-            acc, base_vec, search_box, tiles, dev_points, kernel, coords_i, rho_i, dc, point_id);
+    template <uint8_t Ndim>
+    ALPAKA_FN_ACC std::array<float, Ndim> getCoords(PointsView* d_points, int32_t i) {
+      std::array<float, Ndim> coords;
+      for (auto dim = 0; dim < Ndim; ++dim) {
+        coords[dim] = d_points->coords[i + dim * d_points->n];
       }
+
+      return coords;
     }
-  }
 
-  struct KernelCalculateLocalDensity {
-    template <typename TAcc, uint8_t Ndim, typename KernelType>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  TilesAlpakaView<Ndim>* dev_tiles,
-                                  PointsView* dev_points,
-                                  const KernelType& kernel,
-                                  float dc,
-                                  int32_t n_points) const {
-      for (auto i : alpaka::uniformElements(acc, n_points)) {
-        float rho_i{0.f};
-        auto coords_i = getCoords<Ndim>(dev_points, i);
+    template <typename TAcc, uint8_t Ndim, uint8_t N_, typename KernelType>
+    ALPAKA_FN_HOST_ACC void for_recursion(const TAcc& acc,
+                                          VecArray<int32_t, Ndim>& base_vec,
+                                          const clue::SearchBoxBins<Ndim>& search_box,
+                                          TilesAlpakaView<Ndim>* tiles,
+                                          PointsView* dev_points,
+                                          const KernelType& kernel,
+                                          const std::array<float, Ndim>& coords_i,
+                                          float* rho_i,
+                                          float dc,
+                                          int32_t point_id) {
+      if constexpr (N_ == 0) {
+        auto binId = tiles->getGlobalBinByBin(base_vec);
+        // get the size of this bin
+        auto binSize = (*tiles)[binId].size();
 
-        // Get the extremes of the search box
-        clue::SearchBoxExtremes<Ndim> searchbox_extremes;
-        for (int dim{}; dim != Ndim; ++dim) {
-          searchbox_extremes[dim] = clue::nostd::make_array(coords_i[dim] - dc, coords_i[dim] + dc);
+        // iterate inside this bin
+        for (int binIter{}; binIter < binSize; ++binIter) {
+          int32_t j{(*tiles)[binId][binIter]};
+          // query N_{dc_}(i)
+
+          auto coords_j = getCoords<Ndim>(dev_points, j);
+
+          float dist_ij_sq = tiles->distance(coords_i, coords_j);
+
+          auto k = kernel(acc, clue::internal::math::sqrt(dist_ij_sq), point_id, j);
+          *rho_i += (int)(dist_ij_sq <= dc * dc) * k * dev_points->weight[j];
+
+        }  // end of interate inside this bin
+        return;
+      } else {
+        for (auto i = search_box[search_box.size() - N_][0];
+             i <= search_box[search_box.size() - N_][1];
+             ++i) {
+          base_vec[base_vec.capacity() - N_] = i;
+          for_recursion<TAcc, Ndim, N_ - 1>(
+              acc, base_vec, search_box, tiles, dev_points, kernel, coords_i, rho_i, dc, point_id);
         }
-
-        // Calculate the search box
-        clue::SearchBoxBins<Ndim> searchbox_bins;
-        dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
-
-        VecArray<int32_t, Ndim> base_vec;
-        for_recursion<TAcc, Ndim, Ndim>(
-            acc, base_vec, searchbox_bins, dev_tiles, dev_points, kernel, coords_i, &rho_i, dc, i);
-
-        dev_points->rho[i] = rho_i;
       }
     }
-  };
 
-  template <typename TAcc, uint8_t Ndim, uint8_t N_>
-  ALPAKA_FN_HOST_ACC void for_recursion_nearest_higher(const TAcc& acc,
-                                                       VecArray<int32_t, Ndim>& base_vec,
-                                                       const clue::SearchBoxBins<Ndim>& search_box,
-                                                       TilesAlpakaView<Ndim>* tiles,
-                                                       PointsView* dev_points,
-                                                       const std::array<float, Ndim>& coords_i,
-                                                       float rho_i,
-                                                       float* delta_i,
-                                                       int* nh_i,
-                                                       float dm_sq,
-                                                       int32_t point_id) {
-    if constexpr (N_ == 0) {
-      int binId{tiles->getGlobalBinByBin(base_vec)};
-      // get the size of this bin
-      int binSize{(*tiles)[binId].size()};
+    struct KernelCalculateLocalDensity {
+      template <typename TAcc, uint8_t Ndim, typename KernelType>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    TilesAlpakaView<Ndim>* dev_tiles,
+                                    PointsView* dev_points,
+                                    const KernelType& kernel,
+                                    float dc,
+                                    int32_t n_points) const {
+        for (auto i : alpaka::uniformElements(acc, n_points)) {
+          float rho_i{0.f};
+          auto coords_i = getCoords<Ndim>(dev_points, i);
 
-      // iterate inside this bin
-      for (int binIter{}; binIter < binSize; ++binIter) {
-        const auto j{(*tiles)[binId][binIter]};
-        // query N'_{dm}(i)
-        float rho_j{dev_points->rho[j]};
-        bool found_higher{(rho_j > rho_i)};
-        // in the rare case where rho is the same, use detid
-        found_higher = found_higher || ((rho_j == rho_i) && (rho_j > 0.f) && (j > point_id));
-
-        // Calculate the distance between the two points
-        auto coords_j = getCoords<Ndim>(dev_points, j);
-
-        float dist_ij_sq = tiles->distance(coords_i, coords_j);
-
-        if (found_higher && dist_ij_sq <= dm_sq) {
-          // find the nearest point within N'_{dm}(i)
-          if (dist_ij_sq < *delta_i) {
-            // update delta_i and nearestHigher_i
-            *delta_i = dist_ij_sq;
-            *nh_i = j;
+          // Get the extremes of the search box
+          clue::SearchBoxExtremes<Ndim> searchbox_extremes;
+          for (int dim{}; dim != Ndim; ++dim) {
+            searchbox_extremes[dim] =
+                clue::nostd::make_array(coords_i[dim] - dc, coords_i[dim] + dc);
           }
-        }
-      }  // end of interate inside this bin
 
-      return;
-    } else {
-      for (auto i = search_box[search_box.size() - N_][0];
-           i <= search_box[search_box.size() - N_][1];
-           ++i) {
-        base_vec[base_vec.capacity() - N_] = i;
-        for_recursion_nearest_higher<TAcc, Ndim, N_ - 1>(acc,
+          // Calculate the search box
+          clue::SearchBoxBins<Ndim> searchbox_bins;
+          dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
+
+          VecArray<int32_t, Ndim> base_vec;
+          for_recursion<TAcc, Ndim, Ndim>(
+              acc, base_vec, searchbox_bins, dev_tiles, dev_points, kernel, coords_i, &rho_i, dc, i);
+
+          dev_points->rho[i] = rho_i;
+        }
+      }
+    };
+
+    template <typename TAcc, uint8_t Ndim, uint8_t N_>
+    ALPAKA_FN_HOST_ACC void for_recursion_nearest_higher(const TAcc& acc,
+                                                         VecArray<int32_t, Ndim>& base_vec,
+                                                         const clue::SearchBoxBins<Ndim>& search_box,
+                                                         TilesAlpakaView<Ndim>* tiles,
+                                                         PointsView* dev_points,
+                                                         const std::array<float, Ndim>& coords_i,
+                                                         float rho_i,
+                                                         float* delta_i,
+                                                         int* nh_i,
+                                                         float dm_sq,
+                                                         int32_t point_id) {
+      if constexpr (N_ == 0) {
+        int binId{tiles->getGlobalBinByBin(base_vec)};
+        // get the size of this bin
+        int binSize{(*tiles)[binId].size()};
+
+        // iterate inside this bin
+        for (int binIter{}; binIter < binSize; ++binIter) {
+          const auto j{(*tiles)[binId][binIter]};
+          // query N'_{dm}(i)
+          float rho_j{dev_points->rho[j]};
+          bool found_higher{(rho_j > rho_i)};
+          // in the rare case where rho is the same, use detid
+          found_higher = found_higher || ((rho_j == rho_i) && (rho_j > 0.f) && (j > point_id));
+
+          // Calculate the distance between the two points
+          auto coords_j = getCoords<Ndim>(dev_points, j);
+
+          float dist_ij_sq = tiles->distance(coords_i, coords_j);
+
+          if (found_higher && dist_ij_sq <= dm_sq) {
+            // find the nearest point within N'_{dm}(i)
+            if (dist_ij_sq < *delta_i) {
+              // update delta_i and nearestHigher_i
+              *delta_i = dist_ij_sq;
+              *nh_i = j;
+            }
+          }
+        }  // end of interate inside this bin
+
+        return;
+      } else {
+        for (auto i = search_box[search_box.size() - N_][0];
+             i <= search_box[search_box.size() - N_][1];
+             ++i) {
+          base_vec[base_vec.capacity() - N_] = i;
+          for_recursion_nearest_higher<TAcc, Ndim, N_ - 1>(acc,
+                                                           base_vec,
+                                                           search_box,
+                                                           tiles,
+                                                           dev_points,
+                                                           coords_i,
+                                                           rho_i,
+                                                           delta_i,
+                                                           nh_i,
+                                                           dm_sq,
+                                                           point_id);
+        }
+      }
+    }
+
+    struct KernelCalculateNearestHigher {
+      template <typename TAcc, uint8_t Ndim>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    TilesAlpakaView<Ndim>* dev_tiles,
+                                    PointsView* dev_points,
+                                    float dm,
+                                    int32_t n_points) const {
+        float dm_squared{dm * dm};
+        for (auto i : alpaka::uniformElements(acc, n_points)) {
+          float delta_i{std::numeric_limits<float>::max()};
+          int nh_i{-1};
+          auto coords_i = getCoords<Ndim>(dev_points, i);
+          float rho_i{dev_points->rho[i]};
+
+          // Get the extremes of the search box
+          clue::SearchBoxExtremes<Ndim> searchbox_extremes;
+          for (int dim{}; dim != Ndim; ++dim) {
+            searchbox_extremes[dim] =
+                clue::nostd::make_array(coords_i[dim] - dm, coords_i[dim] + dm);
+          }
+
+          // Calculate the search box
+          clue::SearchBoxBins<Ndim> searchbox_bins;
+          dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
+
+          VecArray<int32_t, Ndim> base_vec{};
+          for_recursion_nearest_higher<TAcc, Ndim, Ndim>(acc,
                                                          base_vec,
-                                                         search_box,
-                                                         tiles,
+                                                         searchbox_bins,
+                                                         dev_tiles,
                                                          dev_points,
                                                          coords_i,
                                                          rho_i,
-                                                         delta_i,
-                                                         nh_i,
-                                                         dm_sq,
-                                                         point_id);
-      }
-    }
-  }
+                                                         &delta_i,
+                                                         &nh_i,
+                                                         dm_squared,
+                                                         i);
 
-  struct KernelCalculateNearestHigher {
-    template <typename TAcc, uint8_t Ndim>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  TilesAlpakaView<Ndim>* dev_tiles,
-                                  PointsView* dev_points,
-                                  float dm,
-                                  int32_t n_points) const {
-      float dm_squared{dm * dm};
-      for (auto i : alpaka::uniformElements(acc, n_points)) {
-        float delta_i{std::numeric_limits<float>::max()};
-        int nh_i{-1};
-        auto coords_i = getCoords<Ndim>(dev_points, i);
-        float rho_i{dev_points->rho[i]};
-
-        // Get the extremes of the search box
-        clue::SearchBoxExtremes<Ndim> searchbox_extremes;
-        for (int dim{}; dim != Ndim; ++dim) {
-          searchbox_extremes[dim] = clue::nostd::make_array(coords_i[dim] - dm, coords_i[dim] + dm);
-        }
-
-        // Calculate the search box
-        clue::SearchBoxBins<Ndim> searchbox_bins;
-        dev_tiles->searchBox(searchbox_extremes, searchbox_bins);
-
-        VecArray<int32_t, Ndim> base_vec{};
-        for_recursion_nearest_higher<TAcc, Ndim, Ndim>(acc,
-                                                       base_vec,
-                                                       searchbox_bins,
-                                                       dev_tiles,
-                                                       dev_points,
-                                                       coords_i,
-                                                       rho_i,
-                                                       &delta_i,
-                                                       &nh_i,
-                                                       dm_squared,
-                                                       i);
-
-        dev_points->delta[i] = clue::internal::math::sqrt(delta_i);
-        dev_points->nearest_higher[i] = nh_i;
-      }
-    }
-  };
-
-  struct KernelFindClusters {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  VecArray<int32_t, reserve>* seeds,
-                                  PointsView* dev_points,
-                                  float seed_dc,
-                                  float rhoc,
-                                  int32_t n_points) const {
-      for (auto i : alpaka::uniformElements(acc, n_points)) {
-        // initialize cluster_index
-        dev_points->cluster_index[i] = -1;
-
-        float delta_i = dev_points->delta[i];
-        float rho_i = dev_points->rho[i];
-
-        // Determine whether the point is a seed or an outlier
-        bool is_seed = (delta_i > seed_dc) && (rho_i >= rhoc);
-
-        if (is_seed) {
-          dev_points->is_seed[i] = 1;
-          seeds->push_back(acc, i);
-        } else {
-          dev_points->is_seed[i] = 0;
+          dev_points->delta[i] = clue::internal::math::sqrt(delta_i);
+          dev_points->nearest_higher[i] = nh_i;
         }
       }
-    }
-  };
+    };
 
-  struct KernelAssignClusters {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  VecArray<int32_t, reserve>* seeds,
-                                  clue::FollowersView* followers,
-                                  PointsView* dev_points) const {
-      const auto& seeds_0{*seeds};
-      const auto n_seeds{seeds_0.size()};
-      for (auto idx_cls : alpaka::uniformElements(acc, n_seeds)) {
-        int local_stack[256] = {-1};
-        int local_stack_size{};
+    struct KernelFindClusters {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    VecArray<int32_t, reserve>* seeds,
+                                    PointsView* dev_points,
+                                    float seed_dc,
+                                    float rhoc,
+                                    int32_t n_points) const {
+        for (auto i : alpaka::uniformElements(acc, n_points)) {
+          // initialize cluster_index
+          dev_points->cluster_index[i] = -1;
 
-        int idx_this_seed = seeds_0[idx_cls];
-        dev_points->cluster_index[idx_this_seed] = idx_cls;
-        // push_back idThisSeed to localStack
-        local_stack[local_stack_size] = idx_this_seed;
-        ++local_stack_size;
-        // process all elements in localStack
-        while (local_stack_size > 0) {
-          // get last element of localStack
-          int idx_end_of_local_stack{local_stack[local_stack_size - 1]};
-          int temp_cluster_index = dev_points->cluster_index[idx_end_of_local_stack];
-          // pop_back last element of localStack
-          local_stack[local_stack_size - 1] = -1;
-          --local_stack_size;
-          const auto& followers_ies = (*followers)[idx_end_of_local_stack];
-          const auto followers_size = followers_ies.size();
-          // loop over followers of last element of localStack
-          for (int j{}; j != followers_size; ++j) {
-            // pass id to follower
-            int follower = followers_ies[j];
-            dev_points->cluster_index[follower] = temp_cluster_index;
-            // push_back follower to localStack
-            local_stack[local_stack_size] = follower;
-            ++local_stack_size;
+          float delta_i = dev_points->delta[i];
+          float rho_i = dev_points->rho[i];
+
+          // Determine whether the point is a seed or an outlier
+          bool is_seed = (delta_i > seed_dc) && (rho_i >= rhoc);
+
+          if (is_seed) {
+            dev_points->is_seed[i] = 1;
+            seeds->push_back(acc, i);
+          } else {
+            dev_points->is_seed[i] = 0;
           }
         }
       }
-    }
-  };
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE
+    };
+
+    struct KernelAssignClusters {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    VecArray<int32_t, reserve>* seeds,
+                                    clue::FollowersView* followers,
+                                    PointsView* dev_points) const {
+        const auto& seeds_0{*seeds};
+        const auto n_seeds{seeds_0.size()};
+        for (auto idx_cls : alpaka::uniformElements(acc, n_seeds)) {
+          int local_stack[256] = {-1};
+          int local_stack_size{};
+
+          int idx_this_seed = seeds_0[idx_cls];
+          dev_points->cluster_index[idx_this_seed] = idx_cls;
+          // push_back idThisSeed to localStack
+          local_stack[local_stack_size] = idx_this_seed;
+          ++local_stack_size;
+          // process all elements in localStack
+          while (local_stack_size > 0) {
+            // get last element of localStack
+            int idx_end_of_local_stack{local_stack[local_stack_size - 1]};
+            int temp_cluster_index = dev_points->cluster_index[idx_end_of_local_stack];
+            // pop_back last element of localStack
+            local_stack[local_stack_size - 1] = -1;
+            --local_stack_size;
+            const auto& followers_ies = (*followers)[idx_end_of_local_stack];
+            const auto followers_size = followers_ies.size();
+            // loop over followers of last element of localStack
+            for (int j{}; j != followers_size; ++j) {
+              // pass id to follower
+              int follower = followers_ies[j];
+              dev_points->cluster_index[follower] = temp_cluster_index;
+              // push_back follower to localStack
+              local_stack[local_stack_size] = follower;
+              ++local_stack_size;
+            }
+          }
+        }
+      }
+    };
+
+  }  // namespace internal
+}  // namespace clue

--- a/include/CLUEstering/core/defines.hpp
+++ b/include/CLUEstering/core/defines.hpp
@@ -1,0 +1,20 @@
+
+#pragma once
+
+#include "CLUEstering/internal/alpaka/config.hpp"
+
+namespace clue {
+
+  using Platform = ALPAKA_BACKEND::Platform;
+  using Device = ALPAKA_BACKEND::Device;
+  using Queue = ALPAKA_BACKEND::Queue;
+  using Event = ALPAKA_BACKEND::Event;
+
+  namespace internal {
+
+    using namespace alpaka_common;
+    using Acc = ALPAKA_BACKEND::Acc1D;
+
+  }  // namespace internal
+
+}  // namespace clue

--- a/include/CLUEstering/internal/alpaka/config.hpp
+++ b/include/CLUEstering/internal/alpaka/config.hpp
@@ -49,7 +49,7 @@ namespace alpaka_cuda_async {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_cuda_async
+#define ALPAKA_BACKEND alpaka_cuda_async
 }  // namespace alpaka_cuda_async
 
 #endif  // ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
@@ -69,7 +69,7 @@ namespace alpaka_rocm_async {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_rocm_async
+#define ALPAKA_BACKEND alpaka_rocm_async
 }  // namespace alpaka_rocm_async
 #endif
 
@@ -89,7 +89,7 @@ namespace alpaka_sycl_cpu {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_sycl_cpu
+#define ALPAKA_BACKEND alpaka_sycl_cpu
 }  // namespace alpaka_sycl_cpu
 
 #elif ALPAKA_SYCL_ONEAPI_GPU
@@ -107,7 +107,7 @@ namespace alpaka_sycl_gpu {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_sycl_gpu
+#define ALPAKA_BACKEND alpaka_sycl_gpu
 }  // namespace alpaka_sycl_gpu
 
 #endif
@@ -128,7 +128,7 @@ namespace alpaka_serial_sync {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_serial_sync
+#define ALPAKA_BACKEND alpaka_serial_sync
 }  // namespace alpaka_serial_sync
 
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
@@ -148,7 +148,7 @@ namespace alpaka_tbb_async {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_tbb_async
+#define ALPAKA_BACKEND alpaka_tbb_async
 }  // namespace alpaka_tbb_async
 
 #endif  // ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
@@ -168,7 +168,7 @@ namespace alpaka_omp2_async {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-#define ALPAKA_ACCELERATOR_NAMESPACE_CLUE alpaka_omp2_async
+#define ALPAKA_BACKEND alpaka_omp2_async
 }  // namespace alpaka_omp2_async
 
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -8,15 +8,13 @@
 
 #include "doctest.h"
 
-using namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE;
-
 TEST_CASE("Test make_cluster interfaces") {
-  const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(dev_acc);
+  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(dev_acc);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/data_32768.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, Device> d_points(queue, n_points);
+  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -11,17 +11,15 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-using namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE;
-
 TEST_CASE("Test clustering on benchmarking datasets") {
   for (auto i = 10; i < 19; ++i) {
-    const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-    Queue queue(dev_acc);
+    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+    clue::Queue queue(dev_acc);
 
     clue::PointsHost<2> h_points =
         clue::read_csv<2>(queue, fmt::format("../data/data_{}.csv", std::pow(2, i)));
     const auto n_points = h_points.size();
-    clue::PointsDevice<2, Device> d_points(queue, n_points);
+    clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
 
     const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
     clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -41,12 +39,12 @@ TEST_CASE("Test clustering on benchmarking datasets") {
 }
 
 TEST_CASE("Test clustering on sissa") {
-  const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(dev_acc);
+  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(dev_acc);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/sissa.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, Device> d_points(queue, n_points);
+  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
 
   const float dc{20.f}, rhoc{10.f}, outlier{20.f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -64,12 +62,12 @@ TEST_CASE("Test clustering on sissa") {
 }
 
 TEST_CASE("Test clustering on toy detector dataset") {
-  const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(dev_acc);
+  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(dev_acc);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/toyDetector.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, Device> d_points(queue, n_points);
+  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
 
   const float dc{4.5f}, rhoc{2.5f}, outlier{4.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -87,12 +85,12 @@ TEST_CASE("Test clustering on toy detector dataset") {
 }
 
 TEST_CASE("Test clustering on blob dataset") {
-  const auto dev_acc = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(dev_acc);
+  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(dev_acc);
 
   clue::PointsHost<3> h_points = clue::read_csv<3>(queue, "../data/blob.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<3, Device> d_points(queue, n_points);
+  clue::PointsDevice<3, clue::Device> d_points(queue, n_points);
 
   const float dc{1.f}, rhoc{5.f}, outlier{2.f};
   clue::Clusterer<3> algo(queue, dc, rhoc, outlier);

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -1,4 +1,5 @@
 
+#include "CLUEstering/core/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 
 #include <numeric>
@@ -8,11 +9,9 @@
 
 #include "doctest.h"
 
-using namespace ALPAKA_ACCELERATOR_NAMESPACE_CLUE;
-
 TEST_CASE("Test host points with internal allocation") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   clue::PointsHost<2> h_points(queue, size);
@@ -75,8 +74,8 @@ TEST_CASE("Test host points with internal allocation") {
 }
 
 TEST_CASE("Test host points with external allocation of whole buffer") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<std::byte> buffer(clue::soa::host::computeSoASize<2>(size));
@@ -141,8 +140,8 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as spans") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> input(3 * size);
@@ -209,8 +208,8 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as vectors") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> input(3 * size);
@@ -276,8 +275,8 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> input(3 * size);
@@ -343,8 +342,8 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as spans") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> coords(2 * size);
@@ -417,8 +416,8 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as vectors") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> coords(2 * size);
@@ -486,8 +485,8 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(alpaka::Platform<Acc1D>{}, 0u);
-  Queue queue(device);
+  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  clue::Queue queue(device);
 
   const uint32_t size = 1000;
   std::vector<float> coords(2 * size);


### PR DESCRIPTION
This PR removes the `ALPAKA_ACCELERATOR_NAMESPACE`, as it's not needed anymore, and this simplifies noticeably the backend.
It also makes the `Queue`, `Platform`, `Device` and `Event` type publicly available in the `clue` namespace.