### PR TITLE
Move convolutional kernel inside `clue` namespace

### DIFF
--- a/CLUEstering/BindingModules/CMakeLists.txt
+++ b/CLUEstering/BindingModules/CMakeLists.txt
@@ -42,8 +42,7 @@ pybind11_add_module(CLUE_Convolutional_Kernels SHARED
 target_include_directories(
   CLUE_Convolutional_Kernels
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(
   CLUE_Convolutional_Kernels PRIVATE ALPAKA_HOST_ONLY
                                      ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)

--- a/CLUEstering/BindingModules/binding_kernels.cpp
+++ b/CLUEstering/BindingModules/binding_kernels.cpp
@@ -8,7 +8,9 @@
 PYBIND11_MODULE(CLUE_Convolutional_Kernels, m) {
   m.doc() = "Binding of the convolutional kernels used in the CLUE algorithm.";
 
-  pybind11::class_<FlatKernel>(m, "FlatKernel").def(pybind11::init<float>());
-  pybind11::class_<ExponentialKernel>(m, "ExponentialKernel").def(pybind11::init<float, float>());
-  pybind11::class_<GaussianKernel>(m, "GaussianKernel").def(pybind11::init<float, float, float>());
+  pybind11::class_<clue::FlatKernel>(m, "FlatKernel").def(pybind11::init<float>());
+  pybind11::class_<clue::ExponentialKernel>(m, "ExponentialKernel")
+      .def(pybind11::init<float, float>());
+  pybind11::class_<clue::GaussianKernel>(m, "GaussianKernel")
+      .def(pybind11::init<float, float, float>());
 }

--- a/CLUEstering/BindingModules/cuda/CMakeLists.txt
+++ b/CLUEstering/BindingModules/cuda/CMakeLists.txt
@@ -10,10 +10,8 @@ endif()
 set_source_files_properties(binding_gpu_cuda.cpp PROPERTIES LANGUAGE CUDA)
 pybind11_add_module(CLUE_GPU_CUDA SHARED binding_gpu_cuda.cpp)
 target_include_directories(
-  CLUE_GPU_CUDA
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  CLUE_GPU_CUDA PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+                        ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(CLUE_GPU_CUDA PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                                  CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(CLUE_GPU_CUDA PRIVATE --expt-relaxed-constexpr)

--- a/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
+++ b/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
@@ -189,11 +189,11 @@ namespace alpaka_cuda_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const FlatKernel&,
+                                  const clue::FlatKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<FlatKernel>),
+                                  size_t>(&mainRun<clue::FlatKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -203,11 +203,11 @@ namespace alpaka_cuda_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const ExponentialKernel&,
+                                  const clue::ExponentialKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<ExponentialKernel>),
+                                  size_t>(&mainRun<clue::ExponentialKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -217,11 +217,11 @@ namespace alpaka_cuda_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const GaussianKernel&,
+                                  const clue::GaussianKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<GaussianKernel>),
+                                  size_t>(&mainRun<clue::GaussianKernel>),
           "mainRun");
   }
 };  // namespace alpaka_cuda_async

--- a/CLUEstering/BindingModules/hip/CMakeLists.txt
+++ b/CLUEstering/BindingModules/hip/CMakeLists.txt
@@ -7,10 +7,8 @@ set(hip_BASE "${hip_INCLUDE_DIRS}/..")
 set(CMAKE_CXX_COMPILER "${hip_BASE}/bin/hipcc")
 pybind11_add_module(CLUE_GPU_HIP SHARED binding_gpu_hip.cpp)
 target_include_directories(
-  CLUE_GPU_HIP
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  CLUE_GPU_HIP PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(CLUE_GPU_HIP PRIVATE ALPAKA_ACC_GPU_HIP_ENABLED
                                                 CLUE_ENABLE_CACHING_ALLOCATOR)
 target_include_directories(CLUE_GPU_HIP PRIVATE ${hip_INCLUDE_DIRS})

--- a/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
+++ b/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
@@ -189,11 +189,11 @@ namespace alpaka_rocm_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const FlatKernel&,
+                                  const clue::FlatKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<FlatKernel>),
+                                  size_t>(&mainRun<clue::FlatKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -203,11 +203,11 @@ namespace alpaka_rocm_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const ExponentialKernel&,
+                                  const clue::ExponentialKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<ExponentialKernel>),
+                                  size_t>(&mainRun<clue::ExponentialKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -217,11 +217,11 @@ namespace alpaka_rocm_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const GaussianKernel&,
+                                  const clue::GaussianKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<GaussianKernel>),
+                                  size_t>(&mainRun<clue::GaussianKernel>),
           "mainRun");
   }
 };  // namespace alpaka_rocm_async

--- a/CLUEstering/BindingModules/openmp/CMakeLists.txt
+++ b/CLUEstering/BindingModules/openmp/CMakeLists.txt
@@ -1,9 +1,7 @@
 pybind11_add_module(CLUE_CPU_OMP SHARED binding_cpu_omp.cpp)
 target_include_directories(
-  CLUE_CPU_OMP
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  CLUE_CPU_OMP PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(
   CLUE_CPU_OMP PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
                        CLUE_ENABLE_CACHING_ALLOCATOR)

--- a/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
@@ -189,11 +189,11 @@ namespace alpaka_omp2_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const FlatKernel&,
+                                  const clue::FlatKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<FlatKernel>),
+                                  size_t>(&mainRun<clue::FlatKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -203,11 +203,11 @@ namespace alpaka_omp2_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const ExponentialKernel&,
+                                  const clue::ExponentialKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<ExponentialKernel>),
+                                  size_t>(&mainRun<clue::ExponentialKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -217,11 +217,11 @@ namespace alpaka_omp2_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const GaussianKernel&,
+                                  const clue::GaussianKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<GaussianKernel>),
+                                  size_t>(&mainRun<clue::GaussianKernel>),
           "mainRun");
   }
 };  // namespace alpaka_omp2_async

--- a/CLUEstering/BindingModules/serial/CMakeLists.txt
+++ b/CLUEstering/BindingModules/serial/CMakeLists.txt
@@ -1,9 +1,7 @@
 pybind11_add_module(CLUE_CPU_Serial SHARED binding_cpu.cpp)
 target_include_directories(
-  CLUE_CPU_Serial
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  CLUE_CPU_Serial PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+                          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(
   CLUE_CPU_Serial PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
                           CLUE_ENABLE_CACHING_ALLOCATOR)

--- a/CLUEstering/BindingModules/serial/binding_cpu.cpp
+++ b/CLUEstering/BindingModules/serial/binding_cpu.cpp
@@ -190,11 +190,11 @@ namespace alpaka_serial_sync {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const FlatKernel&,
+                                  const clue::FlatKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<FlatKernel>),
+                                  size_t>(&mainRun<clue::FlatKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -204,11 +204,11 @@ namespace alpaka_serial_sync {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const ExponentialKernel&,
+                                  const clue::ExponentialKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<ExponentialKernel>),
+                                  size_t>(&mainRun<clue::ExponentialKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -218,11 +218,11 @@ namespace alpaka_serial_sync {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const GaussianKernel&,
+                                  const clue::GaussianKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<GaussianKernel>),
+                                  size_t>(&mainRun<clue::GaussianKernel>),
           "mainRun");
   }
 };  // namespace alpaka_serial_sync

--- a/CLUEstering/BindingModules/tbb/CMakeLists.txt
+++ b/CLUEstering/BindingModules/tbb/CMakeLists.txt
@@ -1,9 +1,7 @@
 pybind11_add_module(CLUE_CPU_TBB SHARED binding_cpu_tbb.cpp)
 target_include_directories(
-  CLUE_CPU_TBB
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_SOURCE_DIR})
+  CLUE_CPU_TBB PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_SOURCE_DIR})
 target_compile_definitions(
   CLUE_CPU_TBB PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
                        CLUE_ENABLE_CACHING_ALLOCATOR)

--- a/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
+++ b/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
@@ -189,11 +189,11 @@ namespace alpaka_tbb_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const FlatKernel&,
+                                  const clue::FlatKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<FlatKernel>),
+                                  size_t>(&mainRun<clue::FlatKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -203,11 +203,11 @@ namespace alpaka_tbb_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const ExponentialKernel&,
+                                  const clue::ExponentialKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<ExponentialKernel>),
+                                  size_t>(&mainRun<clue::ExponentialKernel>),
           "mainRun");
     m.def("mainRun",
           pybind11::overload_cast<float,
@@ -217,11 +217,11 @@ namespace alpaka_tbb_async {
                                   int,
                                   py::array_t<float>,
                                   py::array_t<int>,
-                                  const GaussianKernel&,
+                                  const clue::GaussianKernel&,
                                   int,
                                   int32_t,
                                   size_t,
-                                  size_t>(&mainRun<GaussianKernel>),
+                                  size_t>(&mainRun<clue::GaussianKernel>),
           "mainRun");
   }
 };  // namespace alpaka_tbb_async

--- a/benchmark/dataset_size/cpu/CMakeLists.txt
+++ b/benchmark/dataset_size/cpu/CMakeLists.txt
@@ -16,8 +16,7 @@ if(TBB_FOUND)
   target_include_directories(
     tbb.out
     PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-            ${CMAKE_SOURCE_DIR}/../../benchmark
-            ${alpaka_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/../../benchmark ${alpaka_SOURCE_DIR}/include
             ${Boost_INCLUDE_DIR})
   target_link_libraries(tbb.out PRIVATE ${pybind_link} TBB::tbb)
   target_compile_definitions(
@@ -32,8 +31,7 @@ if(OpenMP_CXX_FOUND)
   target_include_directories(
     openmp.out
     PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-            ${CMAKE_SOURCE_DIR}/../../benchmark
-            ${alpaka_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/../../benchmark ${alpaka_SOURCE_DIR}/include
             ${Boost_INCLUDE_DIR})
   target_link_libraries(openmp.out PRIVATE ${pybind_link} OpenMP::OpenMP_CXX)
   target_compile_definitions(

--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -85,7 +85,7 @@ void run(clue::PointsHost<2>& h_points,
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
-  algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+  algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
 }
 
 int main(int argc, char* argv[]) {

--- a/benchmark/dataset_size/sycl/CMakeLists.txt
+++ b/benchmark/dataset_size/sycl/CMakeLists.txt
@@ -3,8 +3,7 @@ add_executable(sycl_cpu.out ../main.cpp)
 target_include_directories(
   sycl_cpu.out
   PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_cpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_cpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                             -DALPAKA_SYCL_ONEAPI_CPU -fsycl)
@@ -14,8 +13,7 @@ add_executable(sycl_gpu.out ../main.cpp)
 target_include_directories(
   sycl_gpu.out
   PRIVATE ${CMAKE_SOURCE_DIR}/../../include ${CMAKE_SOURCE_DIR}/../../benchmark
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_gpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_gpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                             -DALPAKA_SYCL_ONEAPI_GPU -fsycl)

--- a/benchmark/profiling/CMakeLists.txt
+++ b/benchmark/profiling/CMakeLists.txt
@@ -14,7 +14,11 @@ endif()
 
 string(APPEND CMAKE_CXX_FLAGS_DEBUG
        " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg")
-string(APPEND CMAKE_CXX_FLAGS "-O2 -funroll-loops -funsafe-math-optimizations -fopt-info-vec -ftree-vectorize -march=native")
+string(
+  APPEND
+  CMAKE_CXX_FLAGS
+  "-O2 -funroll-loops -funsafe-math-optimizations -fopt-info-vec -ftree-vectorize -march=native"
+)
 
 find_package(Boost 1.75.0 REQUIRED)
 
@@ -32,21 +36,28 @@ if(CMAKE_CUDA_COMPILER)
   add_subdirectory(cuda)
 endif()
 
-set(_sycl_search_dirs ${SYCL_ROOT_DIR} /usr/lib /usr/local/lib /opt/intel/oneapi/compiler/latest/linux)
-find_program(SYCL_COMPILER
-			NAMES icpx
-			HINTS ${_sycl_search_dirs}
-			PATH_SUFFIXES bin)
-find_path(SYCL_INCLUDE_DIR
-		 NAMES sycl/sycl.hpp
-		 HINTS ${_sycl_search_dirs}
-		 PATH_SUFFIXES include)
-find_path(SYCL_LIB_DIR
-		 NAMES libsycl.so
-		 HINTS ${_sycl_search_dirs}
-		 PATH_SUFFIXES lib)
+set(_sycl_search_dirs ${SYCL_ROOT_DIR} /usr/lib /usr/local/lib
+                      /opt/intel/oneapi/compiler/latest/linux)
+find_program(
+  SYCL_COMPILER
+  NAMES icpx
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES bin)
+find_path(
+  SYCL_INCLUDE_DIR
+  NAMES sycl/sycl.hpp
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES include)
+find_path(
+  SYCL_LIB_DIR
+  NAMES libsycl.so
+  HINTS ${_sycl_search_dirs}
+  PATH_SUFFIXES lib)
 find_package(oneDPL)
 
-if (oneDPL_FOUND AND SYCL_COMPILER AND SYCL_INCLUDE_DIR AND SYCL_LIB_DIR)
+if(oneDPL_FOUND
+   AND SYCL_COMPILER
+   AND SYCL_INCLUDE_DIR
+   AND SYCL_LIB_DIR)
   add_subdirectory(sycl)
 endif()

--- a/benchmark/profiling/cpu/CMakeLists.txt
+++ b/benchmark/profiling/cpu/CMakeLists.txt
@@ -1,9 +1,8 @@
 # CPU Serial
 add_executable(serial.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
-  serial.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  serial.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                     ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(
   serial.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
                      CLUE_ENABLE_CACHING_ALLOCATOR)
@@ -13,9 +12,8 @@ find_package(TBB)
 if(TBB_FOUND)
   add_executable(tbb.out ${CMAKE_SOURCE_DIR}/main.cpp)
   target_include_directories(
-    tbb.out
-    PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-            ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+    tbb.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                    ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
   target_link_libraries(tbb.out PRIVATE TBB::tbb)
   target_compile_definitions(
     tbb.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
@@ -27,9 +25,8 @@ find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
   add_executable(openmp.out ${CMAKE_SOURCE_DIR}/main.cpp)
   target_include_directories(
-    openmp.out
-    PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-            ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+    openmp.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
   target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX)
   target_compile_definitions(
     openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED

--- a/benchmark/profiling/cuda/CMakeLists.txt
+++ b/benchmark/profiling/cuda/CMakeLists.txt
@@ -10,9 +10,8 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/main.cpp PROPERTIES LANGUAGE
                                                                     CUDA)
 add_executable(cuda.out ${CMAKE_SOURCE_DIR}/main.cpp)
 target_include_directories(
-  cuda.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  cuda.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                   ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                             CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -18,7 +18,7 @@ void run(const std::string& input_file) {
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
-  algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+  algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
   auto clusters = algo.getClusters(h_points);
 }
 

--- a/benchmark/profiling/sycl/CMakeLists.txt
+++ b/benchmark/profiling/sycl/CMakeLists.txt
@@ -5,9 +5,8 @@ set(CMAKE_CXX_FLAGS
 set(CMAKE_CXX_COMPILER ${SYCL_COMPILER})
 add_executable(sycl_cpu.out ../main.cpp)
 target_include_directories(
-  sycl_cpu.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  sycl_cpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_cpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_cpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                             -DALPAKA_SYCL_ONEAPI_CPU -fsycl)
@@ -15,9 +14,8 @@ target_link_libraries(sycl_cpu.out PRIVATE -fsycl)
 
 add_executable(sycl_gpu.out ../main.cpp)
 target_include_directories(
-  sycl_gpu.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../../include
-          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+  sycl_gpu.out PRIVATE ${CMAKE_SOURCE_DIR}/../../include
+                       ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_include_directories(sycl_gpu.out PRIVATE ${oneDPL_DIR})
 target_compile_options(sycl_gpu.out PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                             -DALPAKA_SYCL_ONEAPI_GPU -fsycl)

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -3,6 +3,7 @@
 
 #include "CLUEstering/core/Clusterer.hpp"
 #include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/ConvolutionalKernel.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/alpaka/TilesAlpaka.hpp"

--- a/include/CLUEstering/core/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/ConvolutionalKernel.hpp
@@ -1,65 +1,68 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>
-#include <alpaka/alpaka.hpp>
-
 #include "CLUEstering/internal/math/math.hpp"
 
-class FlatKernel {
-private:
-  float m_flat;
+#include <alpaka/alpaka.hpp>
 
-public:
-  FlatKernel(float flat) : m_flat{flat} {}
+namespace clue {
 
-  template <typename TAcc>
-  ALPAKA_FN_HOST_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const {
-    if (point_id == j) {
-      return 1.f;
-    } else {
-      return m_flat;
+  class FlatKernel {
+  private:
+    float m_flat;
+
+  public:
+    FlatKernel(float flat) : m_flat{flat} {}
+
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const {
+      if (point_id == j) {
+        return 1.f;
+      } else {
+        return m_flat;
+      }
     }
-  }
-};
+  };
 
-class GaussianKernel {
-private:
-  float m_gaus_avg;
-  float m_gaus_std;
-  float m_gaus_amplitude;
+  class GaussianKernel {
+  private:
+    float m_gaus_avg;
+    float m_gaus_std;
+    float m_gaus_amplitude;
 
-public:
-  GaussianKernel(float gaus_avg, float gaus_std, float gaus_amplitude)
-      : m_gaus_avg{gaus_avg}, m_gaus_std{gaus_std}, m_gaus_amplitude{gaus_amplitude} {}
+  public:
+    GaussianKernel(float gaus_avg, float gaus_std, float gaus_amplitude)
+        : m_gaus_avg{gaus_avg}, m_gaus_std{gaus_std}, m_gaus_amplitude{gaus_amplitude} {}
 
-  template <typename TAcc>
-  ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
-    if (point_id == j) {
-      return 1.f;
-    } else {
-      return m_gaus_amplitude *
-             clue::internal::math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
-                                       (2 * m_gaus_std * m_gaus_std));
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
+      if (point_id == j) {
+        return 1.f;
+      } else {
+        return m_gaus_amplitude *
+               clue::internal::math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
+                                         (2 * m_gaus_std * m_gaus_std));
+      }
     }
-  }
-};
+  };
 
-class ExponentialKernel {
-private:
-  float m_exp_avg;
-  float m_exp_amplitude;
+  class ExponentialKernel {
+  private:
+    float m_exp_avg;
+    float m_exp_amplitude;
 
-public:
-  ExponentialKernel(float exp_avg, float exp_amplitude)
-      : m_exp_avg{exp_avg}, m_exp_amplitude{exp_amplitude} {}
+  public:
+    ExponentialKernel(float exp_avg, float exp_amplitude)
+        : m_exp_avg{exp_avg}, m_exp_amplitude{exp_amplitude} {}
 
-  template <typename TAcc>
-  ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
-    if (point_id == j) {
-      return 1.f;
-    } else {
-      return (m_exp_amplitude * clue::internal::math::exp(-m_exp_avg * dist_ij));
+    template <typename TAcc>
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
+      if (point_id == j) {
+        return 1.f;
+      } else {
+        return (m_exp_amplitude * clue::internal::math::exp(-m_exp_avg * dist_ij));
+      }
     }
-  }
-};
+  };
+
+}  // namespace clue

--- a/include/CLUEstering/internal/math/exp/exp.hpp
+++ b/include/CLUEstering/internal/math/exp/exp.hpp
@@ -3,6 +3,7 @@
 
 #include "CLUEstering/internal/math/defines.hpp"
 #include <concepts>
+#include <alpaka/alpaka.hpp>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)

--- a/include/CLUEstering/internal/math/max/max.hpp
+++ b/include/CLUEstering/internal/math/max/max.hpp
@@ -3,6 +3,7 @@
 
 #include "CLUEstering/detail/concepts.hpp"
 #include "CLUEstering/internal/math/defines.hpp"
+#include <alpaka/alpaka.hpp>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)

--- a/include/CLUEstering/internal/math/min/min.hpp
+++ b/include/CLUEstering/internal/math/min/min.hpp
@@ -3,6 +3,7 @@
 
 #include "CLUEstering/detail/concepts.hpp"
 #include "CLUEstering/internal/math/defines.hpp"
+#include <alpaka/alpaka.hpp>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)

--- a/include/CLUEstering/internal/math/pow/pow.hpp
+++ b/include/CLUEstering/internal/math/pow/pow.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "CLUEstering/internal/math/defines.hpp"
+#include <alpaka/alpaka.hpp>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)

--- a/include/CLUEstering/internal/math/sqrt/sqrt.hpp
+++ b/include/CLUEstering/internal/math/sqrt/sqrt.hpp
@@ -3,6 +3,7 @@
 
 #include "CLUEstering/internal/math/defines.hpp"
 #include <concepts>
+#include <alpaka/alpaka.hpp>
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && \
     !defined(ALPAKA_ACC_SYCL_ENABLED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-string(APPEND CMAKE_CXX_FLAGS_DEBUG
-       " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg -fsanitize=address")
+string(
+  APPEND CMAKE_CXX_FLAGS_DEBUG
+  " -DCLUE_DEBUG -D_GLIBCXX_ASSERTIONS -Wall -Wextra -pg -fsanitize=address")
 string(APPEND CMAKE_CXX_FLAGS "-O2")
 
 find_package(Boost 1.75.0 REQUIRED)
@@ -36,7 +37,7 @@ endif()
 FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG        10.2.1  # or another stable version
+  GIT_TAG 10.2.1 # or another stable version
 )
 FetchContent_MakeAvailable(fmt)
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -4,10 +4,8 @@ add_executable(serial.out ${sources})
 target_link_libraries(serial.out PRIVATE fmt::fmt)
 target_include_directories(
   serial.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../include
-          ${doctest_SOURCE_DIR}/doctest
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  PRIVATE ${CMAKE_SOURCE_DIR}/../include ${doctest_SOURCE_DIR}/doctest
+          ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(
   serial.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
                      CLUE_ENABLE_CACHING_ALLOCATOR)
@@ -17,10 +15,8 @@ if(TBB_FOUND)
   add_executable(tbb.out ${sources})
   target_include_directories(
     tbb.out
-    PRIVATE ${CMAKE_SOURCE_DIR}/../include
-            ${doctest_SOURCE_DIR}/doctest
-            ${alpaka_SOURCE_DIR}/include
-            ${Boost_INCLUDE_DIR})
+    PRIVATE ${CMAKE_SOURCE_DIR}/../include ${doctest_SOURCE_DIR}/doctest
+            ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
   target_link_libraries(tbb.out PRIVATE TBB::tbb fmt::fmt)
   target_compile_definitions(
     tbb.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
@@ -33,10 +29,8 @@ if(OpenMP_CXX_FOUND)
   add_executable(openmp.out ${sources})
   target_include_directories(
     openmp.out
-    PRIVATE ${CMAKE_SOURCE_DIR}/../include
-            ${doctest_SOURCE_DIR}/doctest
-            ${alpaka_SOURCE_DIR}/include
-            ${Boost_INCLUDE_DIR})
+    PRIVATE ${CMAKE_SOURCE_DIR}/../include ${doctest_SOURCE_DIR}/doctest
+            ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
   target_link_libraries(openmp.out PRIVATE OpenMP::OpenMP_CXX fmt::fmt)
   target_compile_definitions(
     openmp.out PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -14,11 +14,8 @@ endforeach()
 add_executable(cuda.out ${sources})
 target_link_libraries(cuda.out PRIVATE fmt::fmt)
 target_include_directories(
-  cuda.out
-  PRIVATE ${CMAKE_SOURCE_DIR}/../include
-          ${doctest_SOURCE_DIR}/doctest
-          ${alpaka_SOURCE_DIR}/include
-          ${Boost_INCLUDE_DIR})
+  cuda.out PRIVATE ${CMAKE_SOURCE_DIR}/../include ${doctest_SOURCE_DIR}/doctest
+                   ${alpaka_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                             CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test make_cluster interfaces") {
   auto truth_ids = truth_data.clusterIndexes();
   auto truth_isSeed = truth_data.isSeed();
   SUBCASE("Run clustering without passing device points") {
-    algo.make_clusters(h_points, FlatKernel{.5f}, queue, block_size);
+    algo.make_clusters(h_points, clue::FlatKernel{.5f}, queue, block_size);
     auto clusters = h_points.clusterIndexes();
     auto isSeed = h_points.isSeed();
 
@@ -33,7 +33,7 @@ TEST_CASE("Test make_cluster interfaces") {
   }
 
   SUBCASE("Run clustering without passing the queue") {
-    algo.make_clusters(h_points, d_points, FlatKernel{.5f}, block_size);
+    algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, block_size);
     auto clusters = h_points.clusterIndexes();
     auto isSeed = h_points.isSeed();
 
@@ -42,7 +42,7 @@ TEST_CASE("Test make_cluster interfaces") {
   }
 
   SUBCASE("Run clustering without passing the queue and device points") {
-    algo.make_clusters(h_points, FlatKernel{.5f}, block_size);
+    algo.make_clusters(h_points, clue::FlatKernel{.5f}, block_size);
     auto clusters = h_points.clusterIndexes();
     auto isSeed = h_points.isSeed();
 
@@ -51,7 +51,7 @@ TEST_CASE("Test make_cluster interfaces") {
   }
   SUBCASE("Run clustering from device points") {
     clue::copyToDevice(queue, d_points, h_points);
-    algo.make_clusters(d_points, FlatKernel{.5f}, queue, block_size);
+    algo.make_clusters(d_points, clue::FlatKernel{.5f}, queue, block_size);
     clue::copyToHost(queue, h_points, d_points);
 
     auto clusters = h_points.clusterIndexes();

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Test clustering on benchmarking datasets") {
     clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
     const std::size_t block_size{256};
-    algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+    algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
     auto clusters = h_points.clusterIndexes();
     auto isSeed = h_points.isSeed();
 
@@ -50,7 +50,7 @@ TEST_CASE("Test clustering on sissa") {
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
-  algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+  algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
   auto clusters = h_points.clusterIndexes();
   auto isSeed = h_points.isSeed();
 
@@ -73,7 +73,7 @@ TEST_CASE("Test clustering on toy detector dataset") {
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
-  algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+  algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
   auto clusters = h_points.clusterIndexes();
   auto isSeed = h_points.isSeed();
 
@@ -96,7 +96,7 @@ TEST_CASE("Test clustering on blob dataset") {
   clue::Clusterer<3> algo(queue, dc, rhoc, outlier);
 
   const std::size_t block_size{256};
-  algo.make_clusters(h_points, d_points, FlatKernel{.5f}, queue, block_size);
+  algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, queue, block_size);
   auto clusters = h_points.clusterIndexes();
   auto isSeed = h_points.isSeed();
 


### PR DESCRIPTION
This PR moves the definitions of the convolutional kernels inside the `clue` namespace, effectively making them part of the public user interface.