### PR TITLE
Separate declaration and implementation details of public classes

### DIFF
--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -1,24 +1,14 @@
 
 #pragma once
 
-#include "CLUEstering/core/CLUEAlpakaKernels.hpp"
-#include "CLUEstering/core/ConvolutionalKernel.hpp"
 #include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/CLUEAlpakaKernels.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/data_structures/internal/Followers.hpp"
-#include "CLUEstering/internal/algorithm/algorithm.hpp"
-#include "CLUEstering/utils/validation.hpp"
 
-#include <algorithm>
-#include <alpaka/mem/view/Traits.hpp>
-#include <alpaka/vec/Vec.hpp>
-#include <cmath>
 #include <cstdint>
-#include <iostream>
-#include <ranges>
-#include <utility>
 #include <vector>
 
 namespace clue {
@@ -33,50 +23,18 @@ namespace clue {
     using FollowersDevice = clue::Followers<clue::Device>;
     using Acc = internal::Acc;
 
-    inline static constexpr auto reserve = internal::reserve;
+    inline static constexpr auto reserve = detail::reserve;
 
-    explicit Clusterer(float dc, float rhoc, float dm, float seed_dc = -1.f, int pPBin = 128)
-        : m_dc{dc},
-          m_seed_dc{seed_dc},
-          m_rhoc{rhoc},
-          m_dm{dm},
-          m_pointsPerTile{pPBin},
-          m_wrappedCoordinates{} {
-      if (seed_dc < 0.f) {
-        m_seed_dc = dc;
-      }
-    }
+    explicit Clusterer(float dc, float rhoc, float dm, float seed_dc = -1.f, int pPBin = 128);
     explicit Clusterer(
-        Queue& queue, float dc, float rhoc, float dm, float seed_dc = -1.f, int pPBin = 128)
-        : m_dc{dc},
-          m_seed_dc{seed_dc},
-          m_rhoc{rhoc},
-          m_dm{dm},
-          m_pointsPerTile{pPBin},
-          m_wrappedCoordinates{} {
-      if (seed_dc < 0.f) {
-        m_seed_dc = dc;
-      }
-      init_device(queue);
-    }
+        Queue& queue, float dc, float rhoc, float dm, float seed_dc = -1.f, int pPBin = 128);
     explicit Clusterer(Queue& queue,
                        TilesDevice* tile_buffer,
                        float dc,
                        float rhoc,
                        float dm,
                        float seed_dc = -1.f,
-                       int pPBin = 128)
-        : m_dc{dc},
-          m_seed_dc{seed_dc},
-          m_rhoc{rhoc},
-          m_dm{dm},
-          m_pointsPerTile{pPBin},
-          m_wrappedCoordinates{} {
-      if (seed_dc < 0.f) {
-        m_seed_dc = dc;
-      }
-      init_device(queue, tile_buffer);
-    }
+                       int pPBin = 128);
 
     TilesAlpakaView<Ndim>* m_tiles;
     VecArray<int32_t, reserve>* m_seeds;
@@ -86,72 +44,30 @@ namespace clue {
     void make_clusters(PointsHost& h_points,
                        const KernelType& kernel,
                        Queue& queue,
-                       std::size_t block_size) {
-      d_points = std::make_optional<PointsDevice>(queue, h_points.size());
-      auto& dev_points = *d_points;
-
-      setup(queue, h_points, dev_points);
-      make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
-      alpaka::wait(queue);
-    }
+                       std::size_t block_size);
     template <typename KernelType>
-    void make_clusters(PointsHost& h_points, const KernelType& kernel, std::size_t block_size) {
-      auto device = alpaka::getDevByIdx(Platform{}, 0u);
-      Queue queue(device);
-      init_device(queue);
-
-      d_points = std::make_optional<PointsDevice>(queue, h_points.size());
-      auto& dev_points = *d_points;
-
-      setup(queue, h_points, dev_points);
-      make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
-      alpaka::wait(queue);
-    }
+    void make_clusters(PointsHost& h_points, const KernelType& kernel, std::size_t block_size);
     template <typename KernelType>
     void make_clusters(PointsHost& h_points,
                        PointsDevice& dev_points,
                        const KernelType& kernel,
                        Queue& queue,
-                       std::size_t block_size) {
-      setup(queue, h_points, dev_points);
-      make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
-      alpaka::wait(queue);
-    }
+                       std::size_t block_size);
     template <typename KernelType>
     void make_clusters(PointsHost& h_points,
                        PointsDevice& dev_points,
                        const KernelType& kernel,
-                       std::size_t block_size) {
-      auto device = alpaka::getDevByIdx(Platform{}, 0u);
-      Queue queue(device);
-      init_device(queue);
-
-      setup(queue, h_points, dev_points);
-      make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
-      alpaka::wait(queue);
-    }
+                       std::size_t block_size);
     template <typename KernelType>
     void make_clusters(PointsDevice& dev_points,
                        const KernelType& kernel,
                        Queue& queue,
-                       std::size_t block_size) {
-      setupTiles(queue, dev_points);
-      setupFollowers(queue, dev_points.size());
-      alpaka::memset(queue, *d_seeds, 0x00);
-      make_clusters_impl(dev_points, kernel, queue, block_size);
-      alpaka::wait(queue);
-    }
+                       std::size_t block_size);
 
-    void setWrappedCoordinates(const std::array<uint8_t, Ndim>& wrappedCoordinates) {
-      m_wrappedCoordinates = wrappedCoordinates;
-    }
-    void setWrappedCoordinates(std::array<uint8_t, Ndim>&& wrappedCoordinates) {
-      m_wrappedCoordinates = std::move(wrappedCoordinates);
-    }
+    void setWrappedCoordinates(const std::array<uint8_t, Ndim>& wrappedCoordinates);
+    void setWrappedCoordinates(std::array<uint8_t, Ndim>&& wrappedCoordinates);
     template <typename... TArgs>
-    void setWrappedCoordinates(TArgs... wrappedCoordinates) {
-      m_wrappedCoordinates = {wrappedCoordinates...};
-    }
+    void setWrappedCoordinates(TArgs... wrappedCoordinates);
 
     std::vector<std::vector<int>> getClusters(const PointsHost& h_points);
 
@@ -208,262 +124,6 @@ namespace clue {
                             std::size_t block_size);
   };
 
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::init_device(Queue& queue) {
-    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue);
-    m_seeds = (*d_seeds).data();
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::init_device(Queue& queue, TilesDevice* tile_buffer) {
-    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue);
-    m_seeds = (*d_seeds).data();
-
-    // load tiles from outside
-    d_tiles = *tile_buffer;
-    m_tiles = tile_buffer->view();
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::calculate_tile_size(CoordinateExtremes* min_max,
-                                            float* tile_sizes,
-                                            const PointsHost& h_points,
-                                            int32_t nPerDim) {
-    for (size_t dim{}; dim != Ndim; ++dim) {
-      const float dimMax = *std::ranges::max_element(h_points.coords(dim));
-      const float dimMin = *std::ranges::min_element(h_points.coords(dim));
-
-      min_max->min(dim) = dimMin;
-      min_max->max(dim) = dimMax;
-
-      const float tileSize{(dimMax - dimMin) / nPerDim};
-      tile_sizes[dim] = tileSize;
-    }
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::calculate_tile_size(Queue& queue,
-                                            CoordinateExtremes* min_max,
-                                            float* tile_sizes,
-                                            const PointsDevice& dev_points,
-                                            uint32_t nPerDim) {
-    for (size_t dim{}; dim != Ndim; ++dim) {
-      auto coords = dev_points.coords(dim);
-      const auto* dimMax =
-          clue::internal::algorithm::max_element(coords.data(), coords.data() + coords.size());
-      const auto* dimMin =
-          clue::internal::algorithm::min_element(coords.data(), coords.data() + coords.size());
-
-      auto h_dimMin = make_host_buffer<float>(queue);
-      auto h_dimMax = make_host_buffer<float>(queue);
-      alpaka::memcpy(queue, h_dimMin, make_device_view(alpaka::getDev(queue), *dimMin));
-      alpaka::memcpy(queue, h_dimMax, make_device_view(alpaka::getDev(queue), *dimMax));
-      alpaka::wait(queue);
-
-      min_max->min(dim) = *h_dimMin;
-      min_max->max(dim) = *h_dimMax;
-
-      const float tileSize{(*h_dimMax - *h_dimMin) / nPerDim};
-      tile_sizes[dim] = tileSize;
-    }
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::setupTiles(Queue& queue, const PointsHost& h_points) {
-    // TODO: reconsider the way that we compute the number of tiles
-    auto nTiles =
-        static_cast<int32_t>(std::ceil(h_points.size() / static_cast<float>(m_pointsPerTile)));
-    const auto nPerDim = static_cast<int32_t>(std::ceil(std::pow(nTiles, 1. / Ndim)));
-    nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
-
-    if (!d_tiles.has_value()) {
-      d_tiles = std::make_optional<TilesDevice>(queue, h_points.size(), nTiles);
-      m_tiles = d_tiles->view();
-    }
-    // check if tiles are large enough for current data
-    if (!(alpaka::trait::GetExtents<clue::device_buffer<Device, int32_t[]>>{}(
-              d_tiles->indexes())[0u] >= static_cast<std::size_t>(h_points.size())) or
-        !(alpaka::trait::GetExtents<clue::device_buffer<Device, int32_t[]>>{}(
-              d_tiles->offsets())[0u] >= static_cast<std::size_t>(nTiles))) {
-      d_tiles->initialize(h_points.size(), nTiles, nPerDim, queue);
-    } else {
-      d_tiles->reset(h_points.size(), nTiles, nPerDim, queue);
-    }
-
-    auto min_max = clue::make_host_buffer<CoordinateExtremes>(queue);
-    auto tile_sizes = clue::make_host_buffer<float[Ndim]>(queue);
-    calculate_tile_size(min_max.data(), tile_sizes.data(), h_points, nPerDim);
-
-    alpaka::memcpy(queue, d_tiles->minMax(), min_max);
-    alpaka::memcpy(queue, d_tiles->tileSize(), tile_sizes);
-    alpaka::memcpy(
-        queue, d_tiles->wrapped(), clue::make_host_view(m_wrappedCoordinates.data(), Ndim));
-    alpaka::wait(queue);
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::setupTiles(Queue& queue, const PointsDevice& d_points) {
-    auto nTiles =
-        static_cast<int32_t>(std::ceil(d_points.size() / static_cast<float>(m_pointsPerTile)));
-    const auto nPerDim = static_cast<int32_t>(std::ceil(std::pow(nTiles, 1. / Ndim)));
-    nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
-
-    if (!d_tiles.has_value()) {
-      d_tiles = std::make_optional<TilesDevice>(queue, d_points.size(), nTiles);
-      m_tiles = d_tiles->view();
-    }
-    // check if tiles are large enough for current data
-    if (!(alpaka::trait::GetExtents<clue::device_buffer<clue::Device, int32_t[]>>{}(
-              d_tiles->indexes())[0u] >= d_points.size()) or
-        !(alpaka::trait::GetExtents<clue::device_buffer<clue::Device, int32_t[]>>{}(
-              d_tiles->offsets())[0u] >= static_cast<uint32_t>(nTiles))) {
-      d_tiles->initialize(d_points.size(), nTiles, nPerDim, queue);
-    } else {
-      d_tiles->reset(d_points.size(), nTiles, nPerDim, queue);
-    }
-
-    auto min_max = clue::make_host_buffer<CoordinateExtremes>(queue);
-    auto tile_sizes = clue::make_host_buffer<float[Ndim]>(queue);
-    calculate_tile_size(queue, min_max.data(), tile_sizes.data(), d_points, nPerDim);
-
-    alpaka::memcpy(queue, d_tiles->minMax(), min_max);
-    alpaka::memcpy(queue, d_tiles->tileSize(), tile_sizes);
-    alpaka::memcpy(
-        queue, d_tiles->wrapped(), clue::make_host_view(m_wrappedCoordinates.data(), Ndim));
-    alpaka::wait(queue);
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::setupFollowers(Queue& queue, int32_t n_points) {
-    if (!d_followers.has_value()) {
-      d_followers = std::make_optional<FollowersDevice>(n_points, queue);
-      m_followers = d_followers->view();
-    }
-
-    if (!(d_followers->extents() >= n_points)) {
-      d_followers->initialize(n_points, queue);
-    } else {
-      d_followers->reset(n_points, queue);
-    }
-  }
-
-  template <uint8_t Ndim>
-  void Clusterer<Ndim>::setupPoints(const PointsHost& h_points,
-                                    PointsDevice& dev_points,
-                                    Queue& queue) {
-    clue::copyToDevice(queue, dev_points, h_points);
-
-    alpaka::memset(queue, *d_seeds, 0x00);
-  }
-
-  template <uint8_t Ndim>
-  template <typename KernelType>
-  void Clusterer<Ndim>::make_clusters_impl(PointsHost& h_points,
-                                           PointsDevice& dev_points,
-                                           const KernelType& kernel,
-                                           Queue& queue,
-                                           std::size_t block_size) {
-    const auto nPoints = h_points.size();
-    // fill the tiles
-    d_tiles->template fill<Acc>(queue, dev_points, nPoints);
-
-    const Idx grid_size = clue::divide_up_by(nPoints, block_size);
-    auto working_div = clue::make_workdiv<Acc>(grid_size, block_size);
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelCalculateLocalDensity{},
-                      m_tiles,
-                      dev_points.view(),
-                      kernel,
-                      m_dc,
-                      nPoints);
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelCalculateNearestHigher{},
-                      m_tiles,
-                      dev_points.view(),
-                      m_dm,
-                      nPoints);
-
-    d_followers->template fill<Acc>(queue, dev_points);
-
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelFindClusters{},
-                      m_seeds,
-                      dev_points.view(),
-                      m_seed_dc,
-                      m_rhoc,
-                      nPoints);
-
-    // We change the working division when assigning the clusters
-    const Idx grid_size_seeds = clue::divide_up_by(reserve, block_size);
-    auto working_div_seeds = clue::make_workdiv<Acc>(grid_size_seeds, block_size);
-
-    alpaka::exec<Acc>(queue,
-                      working_div_seeds,
-                      internal::KernelAssignClusters{},
-                      m_seeds,
-                      m_followers,
-                      dev_points.view());
-    alpaka::wait(queue);
-
-    clue::copyToHost(queue, h_points, dev_points);
-  }
-
-  template <uint8_t Ndim>
-  template <typename KernelType>
-  void Clusterer<Ndim>::make_clusters_impl(PointsDevice& dev_points,
-                                           const KernelType& kernel,
-                                           Queue& queue,
-                                           std::size_t block_size) {
-    const auto nPoints = dev_points.size();
-    d_tiles->template fill<Acc>(queue, dev_points, nPoints);
-
-    const Idx grid_size = clue::divide_up_by(nPoints, block_size);
-    auto working_div = clue::make_workdiv<Acc>(grid_size, block_size);
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelCalculateLocalDensity{},
-                      m_tiles,
-                      dev_points.view(),
-                      kernel,
-                      m_dc,
-                      nPoints);
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelCalculateNearestHigher{},
-                      m_tiles,
-                      dev_points.view(),
-                      m_dm,
-                      nPoints);
-
-    d_followers->template fill<Acc>(queue, dev_points);
-
-    alpaka::exec<Acc>(queue,
-                      working_div,
-                      internal::KernelFindClusters{},
-                      m_seeds,
-                      dev_points.view(),
-                      m_seed_dc,
-                      m_rhoc,
-                      nPoints);
-
-    // We change the working division when assigning the clusters
-    const Idx grid_size_seeds = clue::divide_up_by(reserve, block_size);
-    auto working_div_seeds = clue::make_workdiv<Acc>(grid_size_seeds, block_size);
-
-    alpaka::exec<Acc>(queue,
-                      working_div_seeds,
-                      internal::KernelAssignClusters{},
-                      m_seeds,
-                      m_followers,
-                      dev_points.view());
-  }
-
-  template <uint8_t Ndim>
-  std::vector<std::vector<int>> Clusterer<Ndim>::getClusters(const PointsHost& h_points) {
-    return clue::compute_clusters_points(h_points.clusterIndexes());
-  }
-
 }  // namespace clue
+
+#include "CLUEstering/core/detail/Clusterer.hpp"

--- a/include/CLUEstering/core/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/ConvolutionalKernel.hpp
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#include "CLUEstering/internal/math/math.hpp"
-
 #include <alpaka/alpaka.hpp>
 
 namespace clue {
@@ -12,16 +10,10 @@ namespace clue {
     float m_flat;
 
   public:
-    FlatKernel(float flat) : m_flat{flat} {}
+    FlatKernel(float flat);
 
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const {
-      if (point_id == j) {
-        return 1.f;
-      } else {
-        return m_flat;
-      }
-    }
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const;
   };
 
   class GaussianKernel {
@@ -31,19 +23,10 @@ namespace clue {
     float m_gaus_amplitude;
 
   public:
-    GaussianKernel(float gaus_avg, float gaus_std, float gaus_amplitude)
-        : m_gaus_avg{gaus_avg}, m_gaus_std{gaus_std}, m_gaus_amplitude{gaus_amplitude} {}
+    GaussianKernel(float gaus_avg, float gaus_std, float gaus_amplitude);
 
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
-      if (point_id == j) {
-        return 1.f;
-      } else {
-        return m_gaus_amplitude *
-               clue::internal::math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
-                                         (2 * m_gaus_std * m_gaus_std));
-      }
-    }
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
   };
 
   class ExponentialKernel {
@@ -52,17 +35,12 @@ namespace clue {
     float m_exp_amplitude;
 
   public:
-    ExponentialKernel(float exp_avg, float exp_amplitude)
-        : m_exp_avg{exp_avg}, m_exp_amplitude{exp_amplitude} {}
+    ExponentialKernel(float exp_avg, float exp_amplitude);
 
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const {
-      if (point_id == j) {
-        return 1.f;
-      } else {
-        return (m_exp_amplitude * clue::internal::math::exp(-m_exp_avg * dist_ij));
-      }
-    }
+    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
   };
 
 }  // namespace clue
+
+#include "CLUEstering/core/detail/ConvolutionalKernel.hpp"

--- a/include/CLUEstering/core/detail/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/core/detail/CLUEAlpakaKernels.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 
 namespace clue {
-  namespace internal {
+  namespace detail {
 
     using clue::PointsView;
     using clue::TilesAlpakaView;
@@ -283,5 +283,5 @@ namespace clue {
       }
     };
 
-  }  // namespace internal
+  }  // namespace detail
 }  // namespace clue

--- a/include/CLUEstering/core/detail/Clusterer.hpp
+++ b/include/CLUEstering/core/detail/Clusterer.hpp
@@ -1,0 +1,416 @@
+
+#pragma once
+
+#include "CLUEstering/core/Clusterer.hpp"
+#include "CLUEstering/core/ConvolutionalKernel.hpp"
+#include "CLUEstering/core/detail/CLUEAlpakaKernels.hpp"
+#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/data_structures/PointsHost.hpp"
+#include "CLUEstering/data_structures/PointsDevice.hpp"
+#include "CLUEstering/data_structures/Tiles.hpp"
+#include "CLUEstering/data_structures/internal/Followers.hpp"
+#include "CLUEstering/internal/algorithm/algorithm.hpp"
+#include "CLUEstering/utils/validation.hpp"
+
+#include <algorithm>
+#include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/vec/Vec.hpp>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+namespace clue {
+
+  template <uint8_t Ndim>
+  inline Clusterer<Ndim>::Clusterer(float dc, float rhoc, float dm, float seed_dc, int pPBin)
+      : m_dc{dc},
+        m_seed_dc{seed_dc},
+        m_rhoc{rhoc},
+        m_dm{dm},
+        m_pointsPerTile{pPBin},
+        m_wrappedCoordinates{} {
+    if (seed_dc < 0.f) {
+      m_seed_dc = dc;
+    }
+  }
+
+  template <uint8_t Ndim>
+  inline Clusterer<Ndim>::Clusterer(
+      Queue& queue, float dc, float rhoc, float dm, float seed_dc, int pPBin)
+      : m_dc{dc},
+        m_seed_dc{seed_dc},
+        m_rhoc{rhoc},
+        m_dm{dm},
+        m_pointsPerTile{pPBin},
+        m_wrappedCoordinates{} {
+    if (seed_dc < 0.f) {
+      m_seed_dc = dc;
+    }
+    init_device(queue);
+  }
+
+  template <uint8_t Ndim>
+  inline Clusterer<Ndim>::Clusterer(Queue& queue,
+                                    TilesDevice* tile_buffer,
+                                    float dc,
+                                    float rhoc,
+                                    float dm,
+                                    float seed_dc,
+                                    int pPBin)
+      : m_dc{dc},
+        m_seed_dc{seed_dc},
+        m_rhoc{rhoc},
+        m_dm{dm},
+        m_pointsPerTile{pPBin},
+        m_wrappedCoordinates{} {
+    if (seed_dc < 0.f) {
+      m_seed_dc = dc;
+    }
+    init_device(queue, tile_buffer);
+  }
+
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  inline void Clusterer<Ndim>::make_clusters(PointsHost& h_points,
+                                             const KernelType& kernel,
+                                             Queue& queue,
+                                             std::size_t block_size) {
+    d_points = std::make_optional<PointsDevice>(queue, h_points.size());
+    auto& dev_points = *d_points;
+
+    setup(queue, h_points, dev_points);
+    make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
+    alpaka::wait(queue);
+  }
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  inline void Clusterer<Ndim>::make_clusters(PointsHost& h_points,
+                                             const KernelType& kernel,
+                                             std::size_t block_size) {
+    auto device = alpaka::getDevByIdx(Platform{}, 0u);
+    Queue queue(device);
+    init_device(queue);
+
+    d_points = std::make_optional<PointsDevice>(queue, h_points.size());
+    auto& dev_points = *d_points;
+
+    setup(queue, h_points, dev_points);
+    make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
+    alpaka::wait(queue);
+  }
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  inline void Clusterer<Ndim>::make_clusters(PointsHost& h_points,
+                                             PointsDevice& dev_points,
+                                             const KernelType& kernel,
+                                             Queue& queue,
+                                             std::size_t block_size) {
+    setup(queue, h_points, dev_points);
+    make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
+    alpaka::wait(queue);
+  }
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  inline void Clusterer<Ndim>::make_clusters(PointsHost& h_points,
+                                             PointsDevice& dev_points,
+                                             const KernelType& kernel,
+                                             std::size_t block_size) {
+    auto device = alpaka::getDevByIdx(Platform{}, 0u);
+    Queue queue(device);
+    init_device(queue);
+
+    setup(queue, h_points, dev_points);
+    make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
+    alpaka::wait(queue);
+  }
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  inline void Clusterer<Ndim>::make_clusters(PointsDevice& dev_points,
+                                             const KernelType& kernel,
+                                             Queue& queue,
+                                             std::size_t block_size) {
+    setupTiles(queue, dev_points);
+    setupFollowers(queue, dev_points.size());
+    alpaka::memset(queue, *d_seeds, 0x00);
+    make_clusters_impl(dev_points, kernel, queue, block_size);
+    alpaka::wait(queue);
+  }
+
+  template <uint8_t Ndim>
+  inline void Clusterer<Ndim>::setWrappedCoordinates(
+      const std::array<uint8_t, Ndim>& wrappedCoordinates) {
+    m_wrappedCoordinates = wrappedCoordinates;
+  }
+  template <uint8_t Ndim>
+  inline void Clusterer<Ndim>::setWrappedCoordinates(
+      std::array<uint8_t, Ndim>&& wrappedCoordinates) {
+    m_wrappedCoordinates = std::move(wrappedCoordinates);
+  }
+  template <uint8_t Ndim>
+  template <typename... TArgs>
+  inline void Clusterer<Ndim>::setWrappedCoordinates(TArgs... wrappedCoordinates) {
+    m_wrappedCoordinates = {wrappedCoordinates...};
+  }
+
+  template <uint8_t Ndim>
+  inline std::vector<std::vector<int>> Clusterer<Ndim>::getClusters(const PointsHost& h_points) {
+    return clue::compute_clusters_points(h_points.clusterIndexes());
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::init_device(Queue& queue) {
+    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue);
+    m_seeds = (*d_seeds).data();
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::init_device(Queue& queue, TilesDevice* tile_buffer) {
+    d_seeds = clue::make_device_buffer<VecArray<int32_t, reserve>>(queue);
+    m_seeds = (*d_seeds).data();
+
+    // load tiles from outside
+    d_tiles = *tile_buffer;
+    m_tiles = tile_buffer->view();
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::calculate_tile_size(CoordinateExtremes* min_max,
+                                            float* tile_sizes,
+                                            const PointsHost& h_points,
+                                            int32_t nPerDim) {
+    for (size_t dim{}; dim != Ndim; ++dim) {
+      const float dimMax = *std::ranges::max_element(h_points.coords(dim));
+      const float dimMin = *std::ranges::min_element(h_points.coords(dim));
+
+      min_max->min(dim) = dimMin;
+      min_max->max(dim) = dimMax;
+
+      const float tileSize{(dimMax - dimMin) / nPerDim};
+      tile_sizes[dim] = tileSize;
+    }
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::calculate_tile_size(Queue& queue,
+                                            CoordinateExtremes* min_max,
+                                            float* tile_sizes,
+                                            const PointsDevice& dev_points,
+                                            uint32_t nPerDim) {
+    for (size_t dim{}; dim != Ndim; ++dim) {
+      auto coords = dev_points.coords(dim);
+      const auto* dimMax =
+          clue::internal::algorithm::max_element(coords.data(), coords.data() + coords.size());
+      const auto* dimMin =
+          clue::internal::algorithm::min_element(coords.data(), coords.data() + coords.size());
+
+      auto h_dimMin = make_host_buffer<float>(queue);
+      auto h_dimMax = make_host_buffer<float>(queue);
+      alpaka::memcpy(queue, h_dimMin, make_device_view(alpaka::getDev(queue), *dimMin));
+      alpaka::memcpy(queue, h_dimMax, make_device_view(alpaka::getDev(queue), *dimMax));
+      alpaka::wait(queue);
+
+      min_max->min(dim) = *h_dimMin;
+      min_max->max(dim) = *h_dimMax;
+
+      const float tileSize{(*h_dimMax - *h_dimMin) / nPerDim};
+      tile_sizes[dim] = tileSize;
+    }
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::setupTiles(Queue& queue, const PointsHost& h_points) {
+    // TODO: reconsider the way that we compute the number of tiles
+    auto nTiles =
+        static_cast<int32_t>(std::ceil(h_points.size() / static_cast<float>(m_pointsPerTile)));
+    const auto nPerDim = static_cast<int32_t>(std::ceil(std::pow(nTiles, 1. / Ndim)));
+    nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
+
+    if (!d_tiles.has_value()) {
+      d_tiles = std::make_optional<TilesDevice>(queue, h_points.size(), nTiles);
+      m_tiles = d_tiles->view();
+    }
+    // check if tiles are large enough for current data
+    if (!(alpaka::trait::GetExtents<clue::device_buffer<Device, int32_t[]>>{}(
+              d_tiles->indexes())[0u] >= static_cast<std::size_t>(h_points.size())) or
+        !(alpaka::trait::GetExtents<clue::device_buffer<Device, int32_t[]>>{}(
+              d_tiles->offsets())[0u] >= static_cast<std::size_t>(nTiles))) {
+      d_tiles->initialize(h_points.size(), nTiles, nPerDim, queue);
+    } else {
+      d_tiles->reset(h_points.size(), nTiles, nPerDim, queue);
+    }
+
+    auto min_max = clue::make_host_buffer<CoordinateExtremes>(queue);
+    auto tile_sizes = clue::make_host_buffer<float[Ndim]>(queue);
+    calculate_tile_size(min_max.data(), tile_sizes.data(), h_points, nPerDim);
+
+    alpaka::memcpy(queue, d_tiles->minMax(), min_max);
+    alpaka::memcpy(queue, d_tiles->tileSize(), tile_sizes);
+    alpaka::memcpy(
+        queue, d_tiles->wrapped(), clue::make_host_view(m_wrappedCoordinates.data(), Ndim));
+    alpaka::wait(queue);
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::setupTiles(Queue& queue, const PointsDevice& d_points) {
+    auto nTiles =
+        static_cast<int32_t>(std::ceil(d_points.size() / static_cast<float>(m_pointsPerTile)));
+    const auto nPerDim = static_cast<int32_t>(std::ceil(std::pow(nTiles, 1. / Ndim)));
+    nTiles = static_cast<int32_t>(std::pow(nPerDim, Ndim));
+
+    if (!d_tiles.has_value()) {
+      d_tiles = std::make_optional<TilesDevice>(queue, d_points.size(), nTiles);
+      m_tiles = d_tiles->view();
+    }
+    // check if tiles are large enough for current data
+    if (!(alpaka::trait::GetExtents<clue::device_buffer<clue::Device, int32_t[]>>{}(
+              d_tiles->indexes())[0u] >= d_points.size()) or
+        !(alpaka::trait::GetExtents<clue::device_buffer<clue::Device, int32_t[]>>{}(
+              d_tiles->offsets())[0u] >= static_cast<uint32_t>(nTiles))) {
+      d_tiles->initialize(d_points.size(), nTiles, nPerDim, queue);
+    } else {
+      d_tiles->reset(d_points.size(), nTiles, nPerDim, queue);
+    }
+
+    auto min_max = clue::make_host_buffer<CoordinateExtremes>(queue);
+    auto tile_sizes = clue::make_host_buffer<float[Ndim]>(queue);
+    calculate_tile_size(queue, min_max.data(), tile_sizes.data(), d_points, nPerDim);
+
+    alpaka::memcpy(queue, d_tiles->minMax(), min_max);
+    alpaka::memcpy(queue, d_tiles->tileSize(), tile_sizes);
+    alpaka::memcpy(
+        queue, d_tiles->wrapped(), clue::make_host_view(m_wrappedCoordinates.data(), Ndim));
+    alpaka::wait(queue);
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::setupFollowers(Queue& queue, int32_t n_points) {
+    if (!d_followers.has_value()) {
+      d_followers = std::make_optional<FollowersDevice>(n_points, queue);
+      m_followers = d_followers->view();
+    }
+
+    if (!(d_followers->extents() >= n_points)) {
+      d_followers->initialize(n_points, queue);
+    } else {
+      d_followers->reset(n_points, queue);
+    }
+  }
+
+  template <uint8_t Ndim>
+  void Clusterer<Ndim>::setupPoints(const PointsHost& h_points,
+                                    PointsDevice& dev_points,
+                                    Queue& queue) {
+    clue::copyToDevice(queue, dev_points, h_points);
+
+    alpaka::memset(queue, *d_seeds, 0x00);
+  }
+
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  void Clusterer<Ndim>::make_clusters_impl(PointsHost& h_points,
+                                           PointsDevice& dev_points,
+                                           const KernelType& kernel,
+                                           Queue& queue,
+                                           std::size_t block_size) {
+    const auto nPoints = h_points.size();
+    // fill the tiles
+    d_tiles->template fill<Acc>(queue, dev_points, nPoints);
+
+    const Idx grid_size = clue::divide_up_by(nPoints, block_size);
+    auto working_div = clue::make_workdiv<Acc>(grid_size, block_size);
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelCalculateLocalDensity{},
+                      m_tiles,
+                      dev_points.view(),
+                      kernel,
+                      m_dc,
+                      nPoints);
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelCalculateNearestHigher{},
+                      m_tiles,
+                      dev_points.view(),
+                      m_dm,
+                      nPoints);
+
+    d_followers->template fill<Acc>(queue, dev_points);
+
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelFindClusters{},
+                      m_seeds,
+                      dev_points.view(),
+                      m_seed_dc,
+                      m_rhoc,
+                      nPoints);
+
+    // We change the working division when assigning the clusters
+    const Idx grid_size_seeds = clue::divide_up_by(reserve, block_size);
+    auto working_div_seeds = clue::make_workdiv<Acc>(grid_size_seeds, block_size);
+
+    alpaka::exec<Acc>(queue,
+                      working_div_seeds,
+                      detail::KernelAssignClusters{},
+                      m_seeds,
+                      m_followers,
+                      dev_points.view());
+    alpaka::wait(queue);
+
+    clue::copyToHost(queue, h_points, dev_points);
+  }
+
+  template <uint8_t Ndim>
+  template <typename KernelType>
+  void Clusterer<Ndim>::make_clusters_impl(PointsDevice& dev_points,
+                                           const KernelType& kernel,
+                                           Queue& queue,
+                                           std::size_t block_size) {
+    const auto nPoints = dev_points.size();
+    d_tiles->template fill<Acc>(queue, dev_points, nPoints);
+
+    const Idx grid_size = clue::divide_up_by(nPoints, block_size);
+    auto working_div = clue::make_workdiv<Acc>(grid_size, block_size);
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelCalculateLocalDensity{},
+                      m_tiles,
+                      dev_points.view(),
+                      kernel,
+                      m_dc,
+                      nPoints);
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelCalculateNearestHigher{},
+                      m_tiles,
+                      dev_points.view(),
+                      m_dm,
+                      nPoints);
+
+    d_followers->template fill<Acc>(queue, dev_points);
+
+    alpaka::exec<Acc>(queue,
+                      working_div,
+                      detail::KernelFindClusters{},
+                      m_seeds,
+                      dev_points.view(),
+                      m_seed_dc,
+                      m_rhoc,
+                      nPoints);
+
+    // We change the working division when assigning the clusters
+    const Idx grid_size_seeds = clue::divide_up_by(reserve, block_size);
+    auto working_div_seeds = clue::make_workdiv<Acc>(grid_size_seeds, block_size);
+
+    alpaka::exec<Acc>(queue,
+                      working_div_seeds,
+                      detail::KernelAssignClusters{},
+                      m_seeds,
+                      m_followers,
+                      dev_points.view());
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
@@ -1,0 +1,57 @@
+
+#pragma once
+
+#include "CLUEstering/core/ConvolutionalKernel.hpp"
+#include "CLUEstering/internal/math/math.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+namespace clue {
+
+  inline FlatKernel::FlatKernel(float flat) : m_flat{flat} {}
+
+  template <typename TAcc>
+  inline ALPAKA_FN_HOST_ACC float FlatKernel::operator()(const TAcc&,
+                                                         float /*dist_ij*/,
+                                                         int point_id,
+                                                         int j) const {
+    if (point_id == j) {
+      return 1.f;
+    } else {
+      return m_flat;
+    }
+  }
+
+  inline GaussianKernel::GaussianKernel(float gaus_avg, float gaus_std, float gaus_amplitude)
+      : m_gaus_avg{gaus_avg}, m_gaus_std{gaus_std}, m_gaus_amplitude{gaus_amplitude} {}
+
+  template <typename TAcc>
+  inline ALPAKA_FN_HOST_ACC float GaussianKernel::operator()(const TAcc& acc,
+                                                             float dist_ij,
+                                                             int point_id,
+                                                             int j) const {
+    if (point_id == j) {
+      return 1.f;
+    } else {
+      return m_gaus_amplitude *
+             clue::internal::math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
+                                       (2 * m_gaus_std * m_gaus_std));
+    }
+  }
+
+  inline ExponentialKernel::ExponentialKernel(float exp_avg, float exp_amplitude)
+      : m_exp_avg{exp_avg}, m_exp_amplitude{exp_amplitude} {}
+
+  template <typename TAcc>
+  inline ALPAKA_FN_HOST_ACC float ExponentialKernel::operator()(const TAcc& acc,
+                                                                float dist_ij,
+                                                                int point_id,
+                                                                int j) const {
+    if (point_id == j) {
+      return 1.f;
+    } else {
+      return (m_exp_amplitude * clue::internal::math::exp(-m_exp_avg * dist_ij));
+    }
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/data_structures/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/AssociationMap.hpp
@@ -24,67 +24,7 @@ namespace clue {
 
   namespace concepts = detail::concepts;
 
-  template <typename TFunc>
-  struct KernelComputeAssociations {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  size_t size,
-                                  int32_t* associations,
-                                  TFunc func) const {
-      for (auto i : alpaka::uniformElements(acc, size)) {
-        associations[i] = func(i);
-      }
-    }
-  };
-
-  struct KernelComputeAssociationSizes {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  const int32_t* associations,
-                                  int32_t* bin_sizes,
-                                  size_t size) const {
-      for (auto i : alpaka::uniformElements(acc, size)) {
-        if (associations[i] >= 0)
-          alpaka::atomicAdd(acc, &bin_sizes[associations[i]], 1);
-      }
-    }
-  };
-
-  struct KernelFillAssociator {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  int32_t* indexes,
-                                  const int32_t* bin_buffer,
-                                  int32_t* temp_offsets,
-                                  size_t size) const {
-      for (auto i : alpaka::uniformElements(acc, size)) {
-        const auto binId = bin_buffer[i];
-        if (binId >= 0) {
-          auto prev = alpaka::atomicAdd(acc, &temp_offsets[binId], 1);
-          indexes[prev] = i;
-        }
-      }
-    }
-  };
-
-  struct AssociationMapView {
-    int32_t* m_indexes;
-    int32_t* m_offsets;
-    int32_t m_nelements;
-    int32_t m_nbins;
-
-    ALPAKA_FN_ACC Span<int32_t> indexes(size_t bin_id) {
-      auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
-      auto* buf_ptr = m_indexes + m_offsets[bin_id];
-      return Span<int32_t>{buf_ptr, size};
-    }
-    ALPAKA_FN_ACC int32_t offsets(size_t bin_id) { return m_offsets[bin_id]; }
-    ALPAKA_FN_ACC Span<int32_t> operator[](size_t bin_id) {
-      auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
-      auto* buf_ptr = m_indexes + m_offsets[bin_id];
-      return Span<int32_t>{buf_ptr, size};
-    }
-  };
+  struct AssociationMapView;
 
   template <concepts::device TDev>
   class AssociationMap {
@@ -99,204 +39,40 @@ namespace clue {
     };
 
     AssociationMap() = default;
-    // TODO: see above
-    AssociationMap(size_type nelements, size_type nbins, const TDev& dev)
-        : m_indexes{make_device_buffer<mapped_type[]>(dev, nelements)},
-          m_offsets{make_device_buffer<key_type[]>(dev, nbins + 1)},
-          m_hview{make_host_buffer<AssociationMapView>(dev)},
-          m_view{make_device_buffer<AssociationMapView>(dev)},
-          m_nbins{nbins} {
-      m_hview->m_indexes = m_indexes.data();
-      m_hview->m_offsets = m_offsets.data();
-      m_hview->m_nelements = nelements;
-      m_hview->m_nbins = nbins;
-
-      auto queue(dev);
-      alpaka::memcpy(queue, m_view, m_hview);
-      // zero the offset buffer
-      alpaka::memset(queue, m_offsets, 0);
-    }
+    AssociationMap(size_type nelements, size_type nbins, const TDev& dev);
 
     template <concepts::queue TQueue>
-    AssociationMap(size_type nelements, size_type nbins, TQueue& queue)
-        : m_indexes{make_device_buffer<mapped_type[]>(queue, nelements)},
-          m_offsets{make_device_buffer<key_type[]>(queue, nbins + 1)},
-          m_hview{make_host_buffer<AssociationMapView>(queue)},
-          m_view{make_device_buffer<AssociationMapView>(queue)},
-          m_nbins{nbins} {
-      m_hview->m_indexes = m_indexes.data();
-      m_hview->m_offsets = m_offsets.data();
-      m_hview->m_nelements = nelements;
-      m_hview->m_nbins = nbins;
+    AssociationMap(size_type nelements, size_type nbins, TQueue& queue);
 
-      alpaka::memcpy(queue, m_view, m_hview);
-      // zero the offset buffer
-      alpaka::memset(queue, m_offsets, 0);
-    }
-
-    AssociationMapView* view() { return m_view.data(); }
+    AssociationMapView* view();
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void initialize(size_type nelements, size_type nbins, TQueue& queue) {
-      m_indexes = make_device_buffer<int32_t[]>(queue, nelements);
-      m_offsets = make_device_buffer<int32_t[]>(queue, nbins);
-      alpaka::memset(queue, m_offsets, 0);
-      m_nbins = nbins;
-
-      m_hview->m_indexes = m_indexes.data();
-      m_hview->m_offsets = m_offsets.data();
-      m_hview->m_nelements = nelements;
-      m_hview->m_nbins = nbins;
-      alpaka::memcpy(queue, m_view, m_hview);
-    }
+    ALPAKA_FN_HOST void initialize(size_type nelements, size_type nbins, TQueue& queue);
 
     template <concepts::queue TQueue>
-    ALPAKA_FN_HOST void reset(TQueue& queue, size_type nelements, size_type nbins) {
-      alpaka::memset(queue, m_indexes, 0);
-      alpaka::memset(queue, m_offsets, 0);
-      m_nbins = nbins;
+    ALPAKA_FN_HOST void reset(TQueue& queue, size_type nelements, size_type nbins);
 
-      m_hview->m_indexes = m_indexes.data();
-      m_hview->m_offsets = m_offsets.data();
-      m_hview->m_nelements = nelements;
-      m_hview->m_nbins = nbins;
-      alpaka::memcpy(queue, m_view, m_hview);
-    }
+    auto size() const;
 
-    auto size() const { return m_nbins; }
+    auto extents() const;
 
-    auto extents() const {
-      return Extents{
-          alpaka::trait::GetExtents<clue::device_buffer<TDev, mapped_type[]>>{}(m_indexes)[0u],
-          alpaka::trait::GetExtents<clue::device_buffer<TDev, key_type[]>>{}(m_offsets)[0u]};
-    }
+    ALPAKA_FN_HOST const auto& indexes() const;
+    ALPAKA_FN_HOST auto& indexes();
 
-    ALPAKA_FN_HOST const device_buffer<TDev, mapped_type[]>& indexes() const { return m_indexes; }
-    ALPAKA_FN_HOST device_buffer<TDev, mapped_type[]>& indexes() { return m_indexes; }
+    ALPAKA_FN_ACC Span<int32_t> indexes(size_type bin_id);
+    ALPAKA_FN_HOST device_view<TDev, int32_t[]> indexes(const TDev& dev, size_type bin_id);
+    ALPAKA_FN_ACC Span<int32_t> operator[](size_type bin_id);
 
-    ALPAKA_FN_ACC Span<int32_t> indexes(size_type bin_id) {
-      const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
-      auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
-      return Span<mapped_type>{buf_ptr, size};
-    }
-    ALPAKA_FN_HOST device_view<TDev, int32_t[]> indexes(const TDev& dev, size_type bin_id) {
-      const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
-      auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
-      return make_device_view<int32_t[], TDev>(dev, buf_ptr, size);
-    }
-    ALPAKA_FN_ACC Span<int32_t> operator[](size_type bin_id) {
-      const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
-      auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
-      return Span<int32_t>{buf_ptr, size};
-    }
+    ALPAKA_FN_HOST const device_buffer<TDev, int32_t[]>& offsets() const;
+    ALPAKA_FN_HOST device_buffer<TDev, int32_t[]>& offsets();
 
-    ALPAKA_FN_HOST const device_buffer<TDev, int32_t[]>& offsets() const { return m_offsets; }
-    ALPAKA_FN_HOST device_buffer<TDev, int32_t[]>& offsets() { return m_offsets; }
-
-    ALPAKA_FN_ACC int32_t offsets(size_type bin_id) const { return m_offsets[bin_id]; }
+    ALPAKA_FN_ACC int32_t offsets(size_type bin_id) const;
 
     template <concepts::accelerator TAcc, typename TFunc, concepts::queue TQueue>
-    ALPAKA_FN_HOST void fill(size_type size, TFunc func, TQueue& queue) {
-      auto bin_buffer = make_device_buffer<int32_t[]>(queue, size);
-
-      // compute associations
-      const auto blocksize = 512;
-      const auto gridsize = divide_up_by(size, blocksize);
-      const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
-      alpaka::exec<TAcc>(
-          queue, workdiv, KernelComputeAssociations<TFunc>{}, size, bin_buffer.data(), func);
-
-      auto sizes_buffer = make_device_buffer<int32_t[]>(queue, m_nbins);
-      alpaka::memset(queue, sizes_buffer, 0);
-      alpaka::exec<TAcc>(queue,
-                         workdiv,
-                         KernelComputeAssociationSizes{},
-                         bin_buffer.data(),
-                         sizes_buffer.data(),
-                         size);
-
-      // prepare prefix scan
-      auto block_counter = make_device_buffer<int32_t>(queue);
-      alpaka::memset(queue, block_counter, 0);
-
-      const auto blocksize_multiblockscan = 1024;
-      auto gridsize_multiblockscan = divide_up_by(m_nbins, blocksize_multiblockscan);
-      const auto workdiv_multiblockscan =
-          make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
-      const auto dev = alpaka::getDev(queue);
-      auto warp_size = alpaka::getPreferredWarpSize(dev);
-      alpaka::exec<TAcc>(queue,
-                         workdiv_multiblockscan,
-                         multiBlockPrefixScan<int32_t>{},
-                         sizes_buffer.data(),
-                         m_offsets.data() + 1,
-                         m_nbins,
-                         gridsize_multiblockscan,
-                         block_counter.data(),
-                         warp_size);
-
-      // fill associator
-      auto temp_offsets = make_device_buffer<int32_t[]>(queue, m_nbins + 1);
-      alpaka::memcpy(queue,
-                     temp_offsets,
-                     make_device_view(alpaka::getDev(queue), m_offsets.data(), m_nbins + 1));
-      alpaka::exec<TAcc>(queue,
-                         workdiv,
-                         KernelFillAssociator{},
-                         m_indexes.data(),
-                         bin_buffer.data(),
-                         temp_offsets.data(),
-                         size);
-    }
+    ALPAKA_FN_HOST void fill(size_type size, TFunc func, TQueue& queue);
 
     template <concepts::accelerator TAcc, concepts::queue TQueue>
-    ALPAKA_FN_HOST void fill(size_type size, std::span<key_type> associations, TQueue& queue) {
-      const auto blocksize = 512;
-      const auto gridsize = divide_up_by(size, blocksize);
-      const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
-
-      auto sizes_buffer = make_device_buffer<key_type[]>(queue, m_nbins);
-      alpaka::memset(queue, sizes_buffer, 0);
-      alpaka::exec<TAcc>(queue,
-                         workdiv,
-                         KernelComputeAssociationSizes{},
-                         associations.data(),
-                         sizes_buffer.data(),
-                         size);
-
-      // prepare prefix scan
-      auto block_counter = make_device_buffer<int32_t>(queue);
-      alpaka::memset(queue, block_counter, 0);
-
-      const auto blocksize_multiblockscan = 1024;
-      auto gridsize_multiblockscan = divide_up_by(m_nbins, blocksize_multiblockscan);
-      const auto workdiv_multiblockscan =
-          make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
-      const auto dev = alpaka::getDev(queue);
-      auto warp_size = alpaka::getPreferredWarpSize(dev);
-      alpaka::exec<TAcc>(queue,
-                         workdiv_multiblockscan,
-                         multiBlockPrefixScan<key_type>{},
-                         sizes_buffer.data(),
-                         m_offsets.data() + 1,
-                         m_nbins,
-                         gridsize_multiblockscan,
-                         block_counter.data(),
-                         warp_size);
-
-      // fill associator
-      auto temp_offsets = make_device_buffer<key_type[]>(queue, m_nbins + 1);
-      alpaka::memcpy(queue,
-                     temp_offsets,
-                     make_device_view(alpaka::getDev(queue), m_offsets.data(), m_nbins + 1));
-      alpaka::exec<TAcc>(queue,
-                         workdiv,
-                         KernelFillAssociator{},
-                         m_indexes.data(),
-                         associations.data(),
-                         temp_offsets.data(),
-                         size);
-    }
+    ALPAKA_FN_HOST void fill(size_type size, std::span<key_type> associations, TQueue& queue);
 
   private:
     device_buffer<TDev, mapped_type[]> m_indexes;
@@ -307,3 +83,5 @@ namespace clue {
   };
 
 }  // namespace clue
+
+#include "CLUEstering/data_structures/detail/AssociationMap.hpp"

--- a/include/CLUEstering/data_structures/PointsDevice.hpp
+++ b/include/CLUEstering/data_structures/PointsDevice.hpp
@@ -18,69 +18,27 @@ namespace clue {
   namespace soa::device {
 
     template <uint8_t Ndim>
-    int32_t computeSoASize(int32_t n_points) {
-      return ((Ndim + 3) * sizeof(float) + 3 * sizeof(int)) * n_points;
-    }
+    int32_t computeSoASize(int32_t n_points);
 
     template <uint8_t Ndim>
-    void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points) {
-      view->coords = reinterpret_cast<float*>(buffer);
-      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
-      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
-      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
-      view->rho = reinterpret_cast<float*>(buffer + (Ndim + 3) * n_points * sizeof(float));
-      view->delta = reinterpret_cast<float*>(buffer + (Ndim + 4) * n_points * sizeof(float));
-      view->nearest_higher = reinterpret_cast<int*>(buffer + (Ndim + 5) * n_points * sizeof(float));
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points);
     template <uint8_t Ndim>
     void partitionSoAView(PointsView* view,
                           std::byte* alloc_buffer,
                           std::byte* buffer,
-                          int32_t n_points) {
-      view->coords = reinterpret_cast<float*>(buffer);
-      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
-      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
-      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
-      view->rho = reinterpret_cast<float*>(alloc_buffer);
-      view->delta = reinterpret_cast<float*>(alloc_buffer + n_points * sizeof(float));
-      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * n_points * sizeof(float));
-      view->n = n_points;
-    }
+                          int32_t n_points);
     template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 4)
     void partitionSoAView(PointsView* view,
                           std::byte* alloc_buffer,
                           int32_t n_points,
-                          TBuffers... buffer) {
-      auto buffers_tuple = std::make_tuple(buffer...);
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
-      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple));
-      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple));
-      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple));
-      view->rho = reinterpret_cast<float*>(alloc_buffer);
-      view->delta = reinterpret_cast<float*>(alloc_buffer + sizeof(float) * n_points);
-      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * sizeof(float) * n_points);
-      view->n = n_points;
-    }
+                          TBuffers... buffer);
     template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2)
     void partitionSoAView(PointsView* view,
                           std::byte* alloc_buffer,
                           int32_t n_points,
-                          TBuffers... buffers) {
-      auto buffers_tuple = std::make_tuple(buffers...);
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
-      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple) + Ndim * n_points);
-      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple));
-      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple) + n_points);
-      view->rho = reinterpret_cast<float*>(alloc_buffer);
-      view->delta = reinterpret_cast<float*>(alloc_buffer + sizeof(float) * n_points);
-      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * sizeof(float) * n_points);
-      view->n = n_points;
-    }
+                          TBuffers... buffers);
 
   }  // namespace soa::device
 
@@ -88,39 +46,14 @@ namespace clue {
   class PointsDevice {
   public:
     template <concepts::queue TQueue>
-    PointsDevice(TQueue& queue, int32_t n_points)
-        : m_buffer{make_device_buffer<std::byte[]>(queue,
-                                                   soa::device::computeSoASize<Ndim>(n_points))},
-          m_view{make_device_buffer<PointsView>(queue)},
-          m_hostView{make_host_buffer<PointsView>(queue)},
-          m_size{n_points} {
-      soa::device::partitionSoAView<Ndim>(m_hostView.data(), m_buffer.data(), n_points);
-      alpaka::memcpy(queue, m_view, m_hostView);
-    }
+    PointsDevice(TQueue& queue, int32_t n_points);
 
     template <concepts::queue TQueue>
-    PointsDevice(TQueue& queue, int32_t n_points, std::span<std::byte> buffer)
-        : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
-          m_view{make_device_buffer<PointsView>(queue)},
-          m_hostView{make_host_buffer<PointsView>(queue)},
-          m_size{n_points} {
-      assert(buffer.size() == soa::device::computeSoASize<Ndim>(n_points));
-
-      soa::device::partitionSoAView<Ndim>(
-          m_hostView.data(), m_buffer.data(), buffer.data(), n_points);
-      alpaka::memcpy(queue, m_view, m_hostView);
-    }
+    PointsDevice(TQueue& queue, int32_t n_points, std::span<std::byte> buffer);
 
     template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsDevice(TQueue& queue, int32_t n_points, TBuffers... buffers)
-        : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
-          m_view{make_device_buffer<PointsView>(queue)},
-          m_hostView{make_host_buffer<PointsView>(queue)},
-          m_size{n_points} {
-      soa::device::partitionSoAView<Ndim>(m_hostView.data(), m_buffer.data(), n_points, buffers...);
-      alpaka::memcpy(queue, m_view, m_hostView);
-    }
+    PointsDevice(TQueue& queue, int32_t n_points, TBuffers... buffers);
 
     PointsDevice(const PointsDevice&) = delete;
     PointsDevice& operator=(const PointsDevice&) = delete;
@@ -128,53 +61,31 @@ namespace clue {
     PointsDevice& operator=(PointsDevice&&) = default;
     ~PointsDevice() = default;
 
-    ALPAKA_FN_HOST_ACC int32_t size() const { return m_size; }
+    ALPAKA_FN_HOST_ACC int32_t size() const;
 
-    ALPAKA_FN_HOST auto coords(size_t dim) const {
-      assert(dim < Ndim);
-      return std::span<const float>(m_hostView.data()->coords + dim * m_size, m_size);
-    }
-    ALPAKA_FN_HOST auto coords(size_t dim) {
-      assert(dim < Ndim);
-      return std::span<float>(m_hostView.data()->coords + dim * m_size, m_size);
-    }
+    ALPAKA_FN_HOST auto coords(size_t dim) const;
+    ALPAKA_FN_HOST auto coords(size_t dim);
 
-    ALPAKA_FN_HOST auto weight() const {
-      return std::span<const float>(m_hostView.data()->weight, m_size);
-    }
-    ALPAKA_FN_HOST auto weight() { return std::span<float>(m_hostView.data()->weight, m_size); }
+    ALPAKA_FN_HOST auto weight() const;
+    ALPAKA_FN_HOST auto weight();
 
-    ALPAKA_FN_HOST auto rho() const {
-      return std::span<const float>(m_hostView.data()->rho, m_size);
-    }
-    ALPAKA_FN_HOST auto rho() { return std::span<float>(m_hostView.data()->rho, m_size); }
+    ALPAKA_FN_HOST auto rho() const;
+    ALPAKA_FN_HOST auto rho();
 
-    ALPAKA_FN_HOST auto delta() const {
-      return std::span<const float>(m_hostView.data()->delta, m_size);
-    }
-    ALPAKA_FN_HOST auto delta() { return std::span<float>(m_hostView.data()->delta, m_size); }
+    ALPAKA_FN_HOST auto delta() const;
+    ALPAKA_FN_HOST auto delta();
 
-    ALPAKA_FN_HOST auto nearestHigher() const {
-      return std::span<const int>(m_hostView.data()->nearest_higher, m_size);
-    }
-    ALPAKA_FN_HOST auto nearestHigher() {
-      return std::span<int>(m_hostView.data()->nearest_higher, m_size);
-    }
+    ALPAKA_FN_HOST auto nearestHigher() const;
+    ALPAKA_FN_HOST auto nearestHigher();
 
-    ALPAKA_FN_HOST auto clusterIndex() const {
-      return std::span<const int>(m_hostView.data()->cluster_index, m_size);
-    }
-    ALPAKA_FN_HOST auto clusterIndex() {
-      return std::span<int>(m_hostView.data()->cluster_index, m_size);
-    }
+    ALPAKA_FN_HOST auto clusterIndex() const;
+    ALPAKA_FN_HOST auto clusterIndex();
 
-    ALPAKA_FN_HOST auto isSeed() const {
-      return std::span<const int>(m_hostView.data()->is_seed, m_size);
-    }
-    ALPAKA_FN_HOST auto isSeed() { return std::span<int>(m_hostView.data()->is_seed, m_size); }
+    ALPAKA_FN_HOST auto isSeed() const;
+    ALPAKA_FN_HOST auto isSeed();
 
-    ALPAKA_FN_HOST PointsView* view() { return m_view.data(); }
-    ALPAKA_FN_HOST const PointsView* view() const { return m_view.data(); }
+    ALPAKA_FN_HOST const PointsView* view() const;
+    ALPAKA_FN_HOST PointsView* view();
 
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
     friend void copyToHost(_TQueue& queue,
@@ -193,3 +104,5 @@ namespace clue {
   };
 
 }  // namespace clue
+
+#include "CLUEstering/data_structures/detail/PointsDevice.hpp"

--- a/include/CLUEstering/data_structures/PointsHost.hpp
+++ b/include/CLUEstering/data_structures/PointsHost.hpp
@@ -18,63 +18,22 @@ namespace clue {
 
     // No need to allocate temporary buffers on the host
     template <uint8_t Ndim>
-    int32_t computeSoASize(int32_t n_points) {
-      return ((Ndim + 1) * sizeof(float) + 2 * sizeof(int)) * n_points;
-    }
+    int32_t computeSoASize(int32_t n_points);
 
     template <uint8_t Ndim>
-    void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points) {
-      view->coords = reinterpret_cast<float*>(buffer);
-      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
-      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
-      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points);
     template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 4)
-    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffer) {
-      auto buffers_tuple = std::make_tuple(buffer...);
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
-      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple));
-      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple));
-      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple));
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffer);
     template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2)
-    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffers) {
-      auto buffers_tuple = std::make_tuple(buffers...);
-
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
-      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple) + Ndim * n_points);
-      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple));
-      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple) + n_points);
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffers);
     template <uint8_t Ndim, std::ranges::contiguous_range... TBuffers>
       requires(sizeof...(TBuffers) == 4)
-    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers) {
-      auto buffers_tuple = std::forward_as_tuple(std::forward<TBuffers>(buffers)...);
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data());
-      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple).data());
-      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple).data());
-      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple).data());
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers);
     template <uint8_t Ndim, std::ranges::contiguous_range... TBuffers>
       requires(sizeof...(TBuffers) == 2)
-    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers) {
-      auto buffers_tuple = std::forward_as_tuple(std::forward<TBuffers>(buffers)...);
-      // TODO: is reinterpret_cast necessary?
-      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data());
-      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data() + Ndim * n_points);
-      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple).data());
-      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple).data() + n_points);
-      view->n = n_points;
-    }
+    void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers);
 
   }  // namespace soa::host
 
@@ -82,35 +41,18 @@ namespace clue {
   class PointsHost {
   public:
     template <concepts::queue TQueue>
-    PointsHost(TQueue& queue, int32_t n_points)
-        : m_buffer{make_host_buffer<std::byte[]>(queue, soa::host::computeSoASize<Ndim>(n_points))},
-          m_view{make_host_buffer<PointsView>(queue)},
-          m_size{n_points} {
-      soa::host::partitionSoAView<Ndim>(m_view.data(), m_buffer->data(), n_points);
-    }
+    PointsHost(TQueue& queue, int32_t n_points);
 
     template <concepts::queue TQueue>
-    PointsHost(TQueue& queue, int32_t n_points, std::span<std::byte> buffer)
-        : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
-      assert(buffer.size() == soa::host::computeSoASize<Ndim>(n_points));
-
-      soa::host::partitionSoAView<Ndim>(m_view.data(), buffer.data(), n_points);
-    }
+    PointsHost(TQueue& queue, int32_t n_points, std::span<std::byte> buffer);
 
     template <concepts::queue TQueue, std::ranges::contiguous_range... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsHost(TQueue& queue, int32_t n_points, TBuffers&&... buffers)
-        : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
-      soa::host::partitionSoAView<Ndim>(
-          m_view.data(), n_points, std::forward<TBuffers>(buffers)...);
-    }
+    PointsHost(TQueue& queue, int32_t n_points, TBuffers&&... buffers);
 
     template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
       requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
-    PointsHost(TQueue& queue, int32_t n_points, TBuffers... buffers)
-        : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
-      soa::host::partitionSoAView<Ndim>(m_view.data(), n_points, buffers...);
-    }
+    PointsHost(TQueue& queue, int32_t n_points, TBuffers... buffers);
 
     PointsHost(const PointsHost&) = delete;
     PointsHost& operator=(const PointsHost&) = delete;
@@ -118,47 +60,25 @@ namespace clue {
     PointsHost& operator=(PointsHost&&) = default;
     ~PointsHost() = default;
 
-    ALPAKA_FN_HOST int32_t size() const { return m_size; }
+    ALPAKA_FN_HOST int32_t size() const;
 
-    ALPAKA_FN_HOST std::span<const float> coords() const {
-      return std::span<const float>(m_view->coords, static_cast<std::size_t>(m_view->n * Ndim));
-    }
-    ALPAKA_FN_HOST std::span<float> coords() {
-      return std::span<float>(m_view->coords, static_cast<std::size_t>(m_view->n * Ndim));
-    }
+    ALPAKA_FN_HOST std::span<const float> coords() const;
+    ALPAKA_FN_HOST std::span<float> coords();
 
-    ALPAKA_FN_HOST std::span<const float> coords(size_t dim) const {
-      return std::span<const float>(m_view->coords + dim * m_view->n,
-                                    static_cast<std::size_t>(m_view->n));
-    }
-    ALPAKA_FN_HOST std::span<float> coords(size_t dim) {
-      return std::span<float>(m_view->coords + dim * m_view->n,
-                              static_cast<std::size_t>(m_view->n));
-    }
+    ALPAKA_FN_HOST std::span<const float> coords(size_t dim) const;
+    ALPAKA_FN_HOST std::span<float> coords(size_t dim);
 
-    ALPAKA_FN_HOST std::span<const float> weights() const {
-      return std::span<const float>(m_view->weight, static_cast<std::size_t>(m_view->n));
-    }
-    ALPAKA_FN_HOST std::span<float> weights() {
-      return std::span<float>(m_view->weight, static_cast<std::size_t>(m_view->n));
-    }
+    ALPAKA_FN_HOST std::span<const float> weights() const;
+    ALPAKA_FN_HOST std::span<float> weights();
 
-    ALPAKA_FN_HOST std::span<const int> clusterIndexes() const {
-      return std::span<const int>(m_view->cluster_index, static_cast<std::size_t>(m_view->n));
-    }
-    ALPAKA_FN_HOST std::span<int> clusterIndexes() {
-      return std::span<int>(m_view->cluster_index, static_cast<std::size_t>(m_view->n));
-    }
+    ALPAKA_FN_HOST std::span<const int> clusterIndexes() const;
+    ALPAKA_FN_HOST std::span<int> clusterIndexes();
 
-    ALPAKA_FN_HOST std::span<const int> isSeed() const {
-      return std::span<const int>(m_view->is_seed, static_cast<std::size_t>(m_view->n));
-    }
-    ALPAKA_FN_HOST std::span<int> isSeed() {
-      return std::span<int>(m_view->is_seed, static_cast<std::size_t>(m_view->n));
-    }
+    ALPAKA_FN_HOST std::span<const int> isSeed() const;
+    ALPAKA_FN_HOST std::span<int> isSeed();
 
-    ALPAKA_FN_HOST PointsView* view() { return m_view.data(); }
-    ALPAKA_FN_HOST const PointsView* view() const { return m_view.data(); }
+    ALPAKA_FN_HOST const PointsView* view() const;
+    ALPAKA_FN_HOST PointsView* view();
 
     template <concepts::queue _TQueue, uint8_t _Ndim, concepts::device _TDev>
     friend void copyToHost(_TQueue& queue,
@@ -176,3 +96,5 @@ namespace clue {
   };
 
 }  // namespace clue
+
+#include "CLUEstering/data_structures/detail/PointsHost.hpp"

--- a/include/CLUEstering/data_structures/detail/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/detail/AssociationMap.hpp
@@ -1,0 +1,330 @@
+
+#pragma once
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <stdexcept>
+#include <type_traits>
+#include <iostream>
+#include <cassert>
+
+#include <limits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "CLUEstering/data_structures/AssociationMap.hpp"
+#include "CLUEstering/data_structures/internal/Span.hpp"
+#include "CLUEstering/detail/concepts.hpp"
+#include "CLUEstering/internal/alpaka/config.hpp"
+#include "CLUEstering/internal/alpaka/memory.hpp"
+#include "CLUEstering/internal/alpaka/work_division.hpp"
+#include "CLUEstering/internal/algorithm/scan/scan.hpp"
+
+namespace clue {
+
+  namespace concepts = detail::concepts;
+
+  namespace detail {
+
+    template <typename TFunc>
+    struct KernelComputeAssociations {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    size_t size,
+                                    int32_t* associations,
+                                    TFunc func) const {
+        for (auto i : alpaka::uniformElements(acc, size)) {
+          associations[i] = func(i);
+        }
+      }
+    };
+
+    struct KernelComputeAssociationSizes {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    const int32_t* associations,
+                                    int32_t* bin_sizes,
+                                    size_t size) const {
+        for (auto i : alpaka::uniformElements(acc, size)) {
+          if (associations[i] >= 0)
+            alpaka::atomicAdd(acc, &bin_sizes[associations[i]], 1);
+        }
+      }
+    };
+
+    struct KernelFillAssociator {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    int32_t* indexes,
+                                    const int32_t* bin_buffer,
+                                    int32_t* temp_offsets,
+                                    size_t size) const {
+        for (auto i : alpaka::uniformElements(acc, size)) {
+          const auto binId = bin_buffer[i];
+          if (binId >= 0) {
+            auto prev = alpaka::atomicAdd(acc, &temp_offsets[binId], 1);
+            indexes[prev] = i;
+          }
+        }
+      }
+    };
+
+  }  // namespace detail
+
+  struct AssociationMapView {
+    int32_t* m_indexes;
+    int32_t* m_offsets;
+    int32_t m_nelements;
+    int32_t m_nbins;
+
+    ALPAKA_FN_ACC Span<int32_t> indexes(size_t bin_id) {
+      auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
+      auto* buf_ptr = m_indexes + m_offsets[bin_id];
+      return Span<int32_t>{buf_ptr, size};
+    }
+    ALPAKA_FN_ACC int32_t offsets(size_t bin_id) { return m_offsets[bin_id]; }
+    ALPAKA_FN_ACC Span<int32_t> operator[](size_t bin_id) {
+      auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
+      auto* buf_ptr = m_indexes + m_offsets[bin_id];
+      return Span<int32_t>{buf_ptr, size};
+    }
+  };
+
+  template <concepts::device TDev>
+  inline AssociationMap<TDev>::AssociationMap(size_type nelements, size_type nbins, const TDev& dev)
+      : m_indexes{make_device_buffer<mapped_type[]>(dev, nelements)},
+        m_offsets{make_device_buffer<key_type[]>(dev, nbins + 1)},
+        m_hview{make_host_buffer<AssociationMapView>(dev)},
+        m_view{make_device_buffer<AssociationMapView>(dev)},
+        m_nbins{nbins} {
+    m_hview->m_indexes = m_indexes.data();
+    m_hview->m_offsets = m_offsets.data();
+    m_hview->m_nelements = nelements;
+    m_hview->m_nbins = nbins;
+
+    auto queue(dev);
+    alpaka::memcpy(queue, m_view, m_hview);
+    // zero the offset buffer
+    alpaka::memset(queue, m_offsets, 0);
+  }
+
+  template <concepts::device TDev>
+  template <concepts::queue TQueue>
+  inline AssociationMap<TDev>::AssociationMap(size_type nelements, size_type nbins, TQueue& queue)
+      : m_indexes{make_device_buffer<mapped_type[]>(queue, nelements)},
+        m_offsets{make_device_buffer<key_type[]>(queue, nbins + 1)},
+        m_hview{make_host_buffer<AssociationMapView>(queue)},
+        m_view{make_device_buffer<AssociationMapView>(queue)},
+        m_nbins{nbins} {
+    m_hview->m_indexes = m_indexes.data();
+    m_hview->m_offsets = m_offsets.data();
+    m_hview->m_nelements = nelements;
+    m_hview->m_nbins = nbins;
+
+    alpaka::memcpy(queue, m_view, m_hview);
+    // zero the offset buffer
+    alpaka::memset(queue, m_offsets, 0);
+  }
+
+  template <concepts::device TDev>
+  inline AssociationMapView* AssociationMap<TDev>::view() {
+    return m_view.data();
+  }
+
+  template <concepts::device TDev>
+  template <concepts::queue TQueue>
+  inline ALPAKA_FN_HOST void AssociationMap<TDev>::initialize(size_type nelements,
+                                                              size_type nbins,
+                                                              TQueue& queue) {
+    m_indexes = make_device_buffer<int32_t[]>(queue, nelements);
+    m_offsets = make_device_buffer<int32_t[]>(queue, nbins);
+    alpaka::memset(queue, m_offsets, 0);
+    m_nbins = nbins;
+
+    m_hview->m_indexes = m_indexes.data();
+    m_hview->m_offsets = m_offsets.data();
+    m_hview->m_nelements = nelements;
+    m_hview->m_nbins = nbins;
+    alpaka::memcpy(queue, m_view, m_hview);
+  }
+
+  template <concepts::device TDev>
+  template <concepts::queue TQueue>
+  inline ALPAKA_FN_HOST void AssociationMap<TDev>::reset(TQueue& queue,
+                                                         size_type nelements,
+                                                         size_type nbins) {
+    alpaka::memset(queue, m_indexes, 0);
+    alpaka::memset(queue, m_offsets, 0);
+    m_nbins = nbins;
+
+    m_hview->m_indexes = m_indexes.data();
+    m_hview->m_offsets = m_offsets.data();
+    m_hview->m_nelements = nelements;
+    m_hview->m_nbins = nbins;
+    alpaka::memcpy(queue, m_view, m_hview);
+  }
+
+  template <concepts::device TDev>
+  inline auto AssociationMap<TDev>::size() const {
+    return m_nbins;
+  }
+
+  template <concepts::device TDev>
+  inline auto AssociationMap<TDev>::extents() const {
+    return Extents{
+        alpaka::trait::GetExtents<clue::device_buffer<TDev, mapped_type[]>>{}(m_indexes)[0u],
+        alpaka::trait::GetExtents<clue::device_buffer<TDev, key_type[]>>{}(m_offsets)[0u]};
+  }
+
+  template <concepts::device TDev>
+  ALPAKA_FN_HOST inline const auto& AssociationMap<TDev>::indexes() const {
+    return m_indexes;
+  }
+  template <concepts::device TDev>
+  ALPAKA_FN_HOST inline auto& AssociationMap<TDev>::indexes() {
+    return m_indexes;
+  }
+
+  template <concepts::device TDev>
+  ALPAKA_FN_ACC inline Span<int32_t> AssociationMap<TDev>::indexes(size_type bin_id) {
+    const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
+    auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
+    return Span<mapped_type>{buf_ptr, size};
+  }
+  template <concepts::device TDev>
+  ALPAKA_FN_HOST inline device_view<TDev, int32_t[]> AssociationMap<TDev>::indexes(
+      const TDev& dev, size_type bin_id) {
+    const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
+    auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
+    return make_device_view<int32_t[], TDev>(dev, buf_ptr, size);
+  }
+  template <concepts::device TDev>
+  ALPAKA_FN_ACC inline Span<int32_t> AssociationMap<TDev>::operator[](size_type bin_id) {
+    const auto size = m_offsets[bin_id + 1] - m_offsets[bin_id];
+    auto* buf_ptr = m_indexes.data() + m_offsets[bin_id];
+    return Span<int32_t>{buf_ptr, size};
+  }
+
+  template <concepts::device TDev>
+  ALPAKA_FN_HOST inline const device_buffer<TDev, int32_t[]>& AssociationMap<TDev>::offsets() const {
+    return m_offsets;
+  }
+  template <concepts::device TDev>
+  ALPAKA_FN_HOST inline device_buffer<TDev, int32_t[]>& AssociationMap<TDev>::offsets() {
+    return m_offsets;
+  }
+
+  template <concepts::device TDev>
+  ALPAKA_FN_ACC inline int32_t AssociationMap<TDev>::offsets(size_type bin_id) const {
+    return m_offsets[bin_id];
+  }
+
+  template <concepts::device TDev>
+  template <concepts::accelerator TAcc, typename TFunc, concepts::queue TQueue>
+  ALPAKA_FN_HOST inline void AssociationMap<TDev>::fill(size_type size, TFunc func, TQueue& queue) {
+    auto bin_buffer = make_device_buffer<int32_t[]>(queue, size);
+
+    // compute associations
+    const auto blocksize = 512;
+    const auto gridsize = divide_up_by(size, blocksize);
+    const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
+    alpaka::exec<TAcc>(
+        queue, workdiv, detail::KernelComputeAssociations<TFunc>{}, size, bin_buffer.data(), func);
+
+    auto sizes_buffer = make_device_buffer<int32_t[]>(queue, m_nbins);
+    alpaka::memset(queue, sizes_buffer, 0);
+    alpaka::exec<TAcc>(queue,
+                       workdiv,
+                       detail::KernelComputeAssociationSizes{},
+                       bin_buffer.data(),
+                       sizes_buffer.data(),
+                       size);
+
+    // prepare prefix scan
+    auto block_counter = make_device_buffer<int32_t>(queue);
+    alpaka::memset(queue, block_counter, 0);
+
+    const auto blocksize_multiblockscan = 1024;
+    auto gridsize_multiblockscan = divide_up_by(m_nbins, blocksize_multiblockscan);
+    const auto workdiv_multiblockscan =
+        make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
+    const auto dev = alpaka::getDev(queue);
+    auto warp_size = alpaka::getPreferredWarpSize(dev);
+    alpaka::exec<TAcc>(queue,
+                       workdiv_multiblockscan,
+                       multiBlockPrefixScan<int32_t>{},
+                       sizes_buffer.data(),
+                       m_offsets.data() + 1,
+                       m_nbins,
+                       gridsize_multiblockscan,
+                       block_counter.data(),
+                       warp_size);
+
+    // fill associator
+    auto temp_offsets = make_device_buffer<int32_t[]>(queue, m_nbins + 1);
+    alpaka::memcpy(queue,
+                   temp_offsets,
+                   make_device_view(alpaka::getDev(queue), m_offsets.data(), m_nbins + 1));
+    alpaka::exec<TAcc>(queue,
+                       workdiv,
+                       detail::KernelFillAssociator{},
+                       m_indexes.data(),
+                       bin_buffer.data(),
+                       temp_offsets.data(),
+                       size);
+  }
+
+  template <concepts::device TDev>
+  template <concepts::accelerator TAcc, concepts::queue TQueue>
+  ALPAKA_FN_HOST inline void AssociationMap<TDev>::fill(size_type size,
+                                                        std::span<key_type> associations,
+                                                        TQueue& queue) {
+    const auto blocksize = 512;
+    const auto gridsize = divide_up_by(size, blocksize);
+    const auto workdiv = make_workdiv<TAcc>(gridsize, blocksize);
+
+    auto sizes_buffer = make_device_buffer<key_type[]>(queue, m_nbins);
+    alpaka::memset(queue, sizes_buffer, 0);
+    alpaka::exec<TAcc>(queue,
+                       workdiv,
+                       detail::KernelComputeAssociationSizes{},
+                       associations.data(),
+                       sizes_buffer.data(),
+                       size);
+
+    // prepare prefix scan
+    auto block_counter = make_device_buffer<int32_t>(queue);
+    alpaka::memset(queue, block_counter, 0);
+
+    const auto blocksize_multiblockscan = 1024;
+    auto gridsize_multiblockscan = divide_up_by(m_nbins, blocksize_multiblockscan);
+    const auto workdiv_multiblockscan =
+        make_workdiv<TAcc>(gridsize_multiblockscan, blocksize_multiblockscan);
+    const auto dev = alpaka::getDev(queue);
+    auto warp_size = alpaka::getPreferredWarpSize(dev);
+    alpaka::exec<TAcc>(queue,
+                       workdiv_multiblockscan,
+                       multiBlockPrefixScan<key_type>{},
+                       sizes_buffer.data(),
+                       m_offsets.data() + 1,
+                       m_nbins,
+                       gridsize_multiblockscan,
+                       block_counter.data(),
+                       warp_size);
+
+    // fill associator
+    auto temp_offsets = make_device_buffer<key_type[]>(queue, m_nbins + 1);
+    alpaka::memcpy(queue,
+                   temp_offsets,
+                   make_device_view(alpaka::getDev(queue), m_offsets.data(), m_nbins + 1));
+    alpaka::exec<TAcc>(queue,
+                       workdiv,
+                       detail::KernelFillAssociator{},
+                       m_indexes.data(),
+                       associations.data(),
+                       temp_offsets.data(),
+                       size);
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/data_structures/detail/PointsDevice.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsDevice.hpp
@@ -1,0 +1,209 @@
+
+#pragma once
+
+#include "CLUEstering/data_structures/PointsDevice.hpp"
+#include "CLUEstering/data_structures/internal/PointsCommon.hpp"
+#include "CLUEstering/detail/concepts.hpp"
+#include "CLUEstering/internal/alpaka/memory.hpp"
+
+#include <alpaka/alpaka.hpp>
+#include <optional>
+#include <ranges>
+#include <span>
+#include <tuple>
+
+namespace clue {
+
+  namespace concepts = detail::concepts;
+
+  namespace soa::device {
+
+    template <uint8_t Ndim>
+    inline int32_t computeSoASize(int32_t n_points) {
+      return ((Ndim + 3) * sizeof(float) + 3 * sizeof(int)) * n_points;
+    }
+
+    template <uint8_t Ndim>
+    inline void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points) {
+      view->coords = reinterpret_cast<float*>(buffer);
+      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
+      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
+      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
+      view->rho = reinterpret_cast<float*>(buffer + (Ndim + 3) * n_points * sizeof(float));
+      view->delta = reinterpret_cast<float*>(buffer + (Ndim + 4) * n_points * sizeof(float));
+      view->nearest_higher = reinterpret_cast<int*>(buffer + (Ndim + 5) * n_points * sizeof(float));
+      view->n = n_points;
+    }
+    template <uint8_t Ndim>
+    inline void partitionSoAView(PointsView* view,
+                                 std::byte* alloc_buffer,
+                                 std::byte* buffer,
+                                 int32_t n_points) {
+      view->coords = reinterpret_cast<float*>(buffer);
+      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
+      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
+      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
+      view->rho = reinterpret_cast<float*>(alloc_buffer);
+      view->delta = reinterpret_cast<float*>(alloc_buffer + n_points * sizeof(float));
+      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * n_points * sizeof(float));
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
+      requires(sizeof...(TBuffers) == 4)
+    inline void partitionSoAView(PointsView* view,
+                                 std::byte* alloc_buffer,
+                                 int32_t n_points,
+                                 TBuffers... buffer) {
+      auto buffers_tuple = std::make_tuple(buffer...);
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
+      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple));
+      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple));
+      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple));
+      view->rho = reinterpret_cast<float*>(alloc_buffer);
+      view->delta = reinterpret_cast<float*>(alloc_buffer + sizeof(float) * n_points);
+      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * sizeof(float) * n_points);
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
+      requires(sizeof...(TBuffers) == 2)
+    inline void partitionSoAView(PointsView* view,
+                                 std::byte* alloc_buffer,
+                                 int32_t n_points,
+                                 TBuffers... buffers) {
+      auto buffers_tuple = std::make_tuple(buffers...);
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
+      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple) + Ndim * n_points);
+      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple));
+      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple) + n_points);
+      view->rho = reinterpret_cast<float*>(alloc_buffer);
+      view->delta = reinterpret_cast<float*>(alloc_buffer + sizeof(float) * n_points);
+      view->nearest_higher = reinterpret_cast<int*>(alloc_buffer + 2 * sizeof(float) * n_points);
+      view->n = n_points;
+    }
+
+  }  // namespace soa::device
+
+  template <uint8_t Ndim, concepts::device TDev>
+  template <concepts::queue TQueue>
+  inline PointsDevice<Ndim, TDev>::PointsDevice(TQueue& queue, int32_t n_points)
+      : m_buffer{make_device_buffer<std::byte[]>(queue,
+                                                 soa::device::computeSoASize<Ndim>(n_points))},
+        m_view{make_device_buffer<PointsView>(queue)},
+        m_hostView{make_host_buffer<PointsView>(queue)},
+        m_size{n_points} {
+    soa::device::partitionSoAView<Ndim>(m_hostView.data(), m_buffer.data(), n_points);
+    alpaka::memcpy(queue, m_view, m_hostView);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  template <concepts::queue TQueue>
+  inline PointsDevice<Ndim, TDev>::PointsDevice(TQueue& queue,
+                                                int32_t n_points,
+                                                std::span<std::byte> buffer)
+      : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
+        m_view{make_device_buffer<PointsView>(queue)},
+        m_hostView{make_host_buffer<PointsView>(queue)},
+        m_size{n_points} {
+    assert(buffer.size() == soa::device::computeSoASize<Ndim>(n_points));
+
+    soa::device::partitionSoAView<Ndim>(
+        m_hostView.data(), m_buffer.data(), buffer.data(), n_points);
+    alpaka::memcpy(queue, m_view, m_hostView);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
+    requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
+  inline PointsDevice<Ndim, TDev>::PointsDevice(TQueue& queue,
+                                                int32_t n_points,
+                                                TBuffers... buffers)
+      : m_buffer{make_device_buffer<std::byte[]>(queue, 3 * n_points * sizeof(float))},
+        m_view{make_device_buffer<PointsView>(queue)},
+        m_hostView{make_host_buffer<PointsView>(queue)},
+        m_size{n_points} {
+    soa::device::partitionSoAView<Ndim>(m_hostView.data(), m_buffer.data(), n_points, buffers...);
+    alpaka::memcpy(queue, m_view, m_hostView);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST_ACC inline int32_t PointsDevice<Ndim, TDev>::size() const {
+    return m_size;
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::coords(size_t dim) const {
+    assert(dim < Ndim);
+    return std::span<const float>(m_hostView.data()->coords + dim * m_size, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::coords(size_t dim) {
+    assert(dim < Ndim);
+    return std::span<float>(m_hostView.data()->coords + dim * m_size, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::weight() const {
+    return std::span<const float>(m_hostView.data()->weight, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::weight() {
+    return std::span<float>(m_hostView.data()->weight, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::rho() const {
+    return std::span<const float>(m_hostView.data()->rho, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::rho() {
+    return std::span<float>(m_hostView.data()->rho, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::delta() const {
+    return std::span<const float>(m_hostView.data()->delta, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::delta() {
+    return std::span<float>(m_hostView.data()->delta, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::nearestHigher() const {
+    return std::span<const int>(m_hostView.data()->nearest_higher, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::nearestHigher() {
+    return std::span<int>(m_hostView.data()->nearest_higher, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::clusterIndex() const {
+    return std::span<const int>(m_hostView.data()->cluster_index, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::clusterIndex() {
+    return std::span<int>(m_hostView.data()->cluster_index, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::isSeed() const {
+    return std::span<const int>(m_hostView.data()->is_seed, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::isSeed() {
+    return std::span<int>(m_hostView.data()->is_seed, m_size);
+  }
+
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline const PointsView* PointsDevice<Ndim, TDev>::view() const {
+    return m_view.data();
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline PointsView* PointsDevice<Ndim, TDev>::view() {
+    return m_view.data();
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/data_structures/detail/PointsHost.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsHost.hpp
@@ -1,0 +1,175 @@
+
+#pragma once
+
+#include "CLUEstering/data_structures/internal/PointsCommon.hpp"
+#include "CLUEstering/internal/alpaka/memory.hpp"
+
+#include <alpaka/alpaka.hpp>
+#include <optional>
+#include <ranges>
+#include <span>
+#include <tuple>
+
+namespace clue {
+
+  namespace concepts = detail::concepts;
+
+  namespace soa::host {
+
+    // No need to allocate temporary buffers on the host
+    template <uint8_t Ndim>
+    inline int32_t computeSoASize(int32_t n_points) {
+      return ((Ndim + 1) * sizeof(float) + 2 * sizeof(int)) * n_points;
+    }
+
+    template <uint8_t Ndim>
+    inline void partitionSoAView(PointsView* view, std::byte* buffer, int32_t n_points) {
+      view->coords = reinterpret_cast<float*>(buffer);
+      view->weight = reinterpret_cast<float*>(buffer + Ndim * n_points * sizeof(float));
+      view->cluster_index = reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(float));
+      view->is_seed = reinterpret_cast<int*>(buffer + (Ndim + 2) * n_points * sizeof(float));
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
+      requires(sizeof...(TBuffers) == 4)
+    inline void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffer) {
+      auto buffers_tuple = std::make_tuple(buffer...);
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
+      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple));
+      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple));
+      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple));
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, concepts::contiguous_raw_data... TBuffers>
+      requires(sizeof...(TBuffers) == 2)
+    inline void partitionSoAView(PointsView* view, int32_t n_points, TBuffers... buffers) {
+      auto buffers_tuple = std::make_tuple(buffers...);
+
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple));
+      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple) + Ndim * n_points);
+      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple));
+      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple) + n_points);
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, std::ranges::contiguous_range... TBuffers>
+      requires(sizeof...(TBuffers) == 4)
+    inline void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers) {
+      auto buffers_tuple = std::forward_as_tuple(std::forward<TBuffers>(buffers)...);
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data());
+      view->weight = reinterpret_cast<float*>(std::get<1>(buffers_tuple).data());
+      view->cluster_index = reinterpret_cast<int*>(std::get<2>(buffers_tuple).data());
+      view->is_seed = reinterpret_cast<int*>(std::get<3>(buffers_tuple).data());
+      view->n = n_points;
+    }
+    template <uint8_t Ndim, std::ranges::contiguous_range... TBuffers>
+      requires(sizeof...(TBuffers) == 2)
+    inline void partitionSoAView(PointsView* view, int32_t n_points, TBuffers&&... buffers) {
+      auto buffers_tuple = std::forward_as_tuple(std::forward<TBuffers>(buffers)...);
+      // TODO: is reinterpret_cast necessary?
+      view->coords = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data());
+      view->weight = reinterpret_cast<float*>(std::get<0>(buffers_tuple).data() + Ndim * n_points);
+      view->cluster_index = reinterpret_cast<int*>(std::get<1>(buffers_tuple).data());
+      view->is_seed = reinterpret_cast<int*>(std::get<1>(buffers_tuple).data() + n_points);
+      view->n = n_points;
+    }
+
+  }  // namespace soa::host
+
+  template <uint8_t Ndim>
+  template <concepts::queue TQueue>
+  inline PointsHost<Ndim>::PointsHost(TQueue& queue, int32_t n_points)
+      : m_buffer{make_host_buffer<std::byte[]>(queue, soa::host::computeSoASize<Ndim>(n_points))},
+        m_view{make_host_buffer<PointsView>(queue)},
+        m_size{n_points} {
+    soa::host::partitionSoAView<Ndim>(m_view.data(), m_buffer->data(), n_points);
+  }
+
+  template <uint8_t Ndim>
+  template <concepts::queue TQueue>
+  inline PointsHost<Ndim>::PointsHost(TQueue& queue, int32_t n_points, std::span<std::byte> buffer)
+      : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
+    assert(buffer.size() == soa::host::computeSoASize<Ndim>(n_points));
+
+    soa::host::partitionSoAView<Ndim>(m_view.data(), buffer.data(), n_points);
+  }
+
+  template <uint8_t Ndim>
+  template <concepts::queue TQueue, std::ranges::contiguous_range... TBuffers>
+    requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
+  inline PointsHost<Ndim>::PointsHost(TQueue& queue, int32_t n_points, TBuffers&&... buffers)
+      : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
+    soa::host::partitionSoAView<Ndim>(m_view.data(), n_points, std::forward<TBuffers>(buffers)...);
+  }
+
+  template <uint8_t Ndim>
+  template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
+    requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
+  inline PointsHost<Ndim>::PointsHost(TQueue& queue, int32_t n_points, TBuffers... buffers)
+      : m_view{make_host_buffer<PointsView>(queue)}, m_size{n_points} {
+    soa::host::partitionSoAView<Ndim>(m_view.data(), n_points, buffers...);
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline int32_t PointsHost<Ndim>::size() const {
+    return m_size;
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<const float> PointsHost<Ndim>::coords() const {
+    return std::span<const float>(m_view->coords, static_cast<std::size_t>(m_view->n * Ndim));
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<float> PointsHost<Ndim>::coords() {
+    return std::span<float>(m_view->coords, static_cast<std::size_t>(m_view->n * Ndim));
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<const float> PointsHost<Ndim>::coords(size_t dim) const {
+    return std::span<const float>(m_view->coords + dim * m_view->n,
+                                  static_cast<std::size_t>(m_view->n));
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<float> PointsHost<Ndim>::coords(size_t dim) {
+    return std::span<float>(m_view->coords + dim * m_view->n, static_cast<std::size_t>(m_view->n));
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<const float> PointsHost<Ndim>::weights() const {
+    return std::span<const float>(m_view->weight, static_cast<std::size_t>(m_view->n));
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<float> PointsHost<Ndim>::weights() {
+    return std::span<float>(m_view->weight, static_cast<std::size_t>(m_view->n));
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<const int> PointsHost<Ndim>::clusterIndexes() const {
+    return std::span<const int>(m_view->cluster_index, static_cast<std::size_t>(m_view->n));
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<int> PointsHost<Ndim>::clusterIndexes() {
+    return std::span<int>(m_view->cluster_index, static_cast<std::size_t>(m_view->n));
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<const int> PointsHost<Ndim>::isSeed() const {
+    return std::span<const int>(m_view->is_seed, static_cast<std::size_t>(m_view->n));
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline std::span<int> PointsHost<Ndim>::isSeed() {
+    return std::span<int>(m_view->is_seed, static_cast<std::size_t>(m_view->n));
+  }
+
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline PointsView* PointsHost<Ndim>::view() {
+    return m_view.data();
+  }
+  template <uint8_t Ndim>
+  ALPAKA_FN_HOST inline const PointsView* PointsHost<Ndim>::view() const {
+    return m_view.data();
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/utils/detail/read_csv.hpp
+++ b/include/CLUEstering/utils/detail/read_csv.hpp
@@ -1,0 +1,85 @@
+
+#pragma once
+
+#include "CLUEstering/data_structures/PointsHost.hpp"
+#include "CLUEstering/detail/concepts.hpp"
+#include "CLUEstering/utils/read_csv.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace clue {
+  template <size_t NDim, concepts::queue TQueue>
+  inline clue::PointsHost<NDim> read_csv(TQueue& queue, const std::string& file_path) {
+    std::fstream file(file_path);
+    if (!file.is_open()) {
+      throw std::runtime_error("Could not open file: " + file_path);
+    }
+    auto n_points =
+        std::count(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), '\n') -
+        1;
+
+    clue::PointsHost<NDim> points(queue, n_points);
+
+    file = std::fstream(file_path);
+    // discard the header
+    std::string buffer;
+    getline(file, buffer);
+    auto point_id = 0;
+    while (getline(file, buffer)) {
+      std::stringstream buffer_stream(buffer);
+      std::string value;
+
+      for (size_t dim = 0; dim < NDim; ++dim) {
+        getline(buffer_stream, value, ',');
+        points.coords(dim)[point_id] = std::stof(value);
+      }
+      getline(buffer_stream, value);
+      points.weights()[point_id] = std::stof(value);
+      ++point_id;
+    }
+    file.close();
+
+    return points;
+  }
+
+  template <size_t NDim, concepts::queue TQueue>
+  inline clue::PointsHost<NDim> read_output(TQueue& queue, const std::string& file_path) {
+    std::fstream file(file_path);
+    if (!file.is_open()) {
+      throw std::runtime_error("Could not open file: " + file_path);
+    }
+    auto n_points =
+        std::count(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), '\n') -
+        1;
+    clue::PointsHost<NDim> points(queue, n_points);
+
+    file = std::fstream(file_path);
+    // discard the header
+    std::string buffer;
+    getline(file, buffer);
+    auto point_id = 0;
+    while (getline(file, buffer)) {
+      std::stringstream buffer_stream(buffer);
+      std::string value;
+
+      for (size_t dim = 0; dim < NDim; ++dim) {
+        getline(buffer_stream, value, ',');
+        points.coords(dim)[point_id] = std::stof(value);
+      }
+      getline(buffer_stream, value, ',');
+      points.weights()[point_id] = std::stof(value);
+      getline(buffer_stream, value, ',');
+      points.clusterIndexes()[point_id] = std::stoi(value);
+      getline(buffer_stream, value);
+      points.isSeed()[point_id] = std::stoi(value);
+
+      ++point_id;
+    }
+    file.close();
+
+    return points;
+  }
+}  // namespace clue

--- a/include/CLUEstering/utils/read_csv.hpp
+++ b/include/CLUEstering/utils/read_csv.hpp
@@ -4,81 +4,16 @@
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/detail/concepts.hpp"
 
-#include <algorithm>
-#include <fstream>
-#include <sstream>
 #include <string>
 
 namespace clue {
-  template <size_t NDim, concepts::queue TQueue>
-  inline clue::PointsHost<NDim> read_csv(TQueue& queue, const std::string& file_path) {
-    std::fstream file(file_path);
-    if (!file.is_open()) {
-      throw std::runtime_error("Could not open file: " + file_path);
-    }
-    auto n_points =
-        std::count(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), '\n') -
-        1;
-
-    clue::PointsHost<NDim> points(queue, n_points);
-
-    file = std::fstream(file_path);
-    // discard the header
-    std::string buffer;
-    getline(file, buffer);
-    auto point_id = 0;
-    while (getline(file, buffer)) {
-      std::stringstream buffer_stream(buffer);
-      std::string value;
-
-      for (size_t dim = 0; dim < NDim; ++dim) {
-        getline(buffer_stream, value, ',');
-        points.coords(dim)[point_id] = std::stof(value);
-      }
-      getline(buffer_stream, value);
-      points.weights()[point_id] = std::stof(value);
-      ++point_id;
-    }
-    file.close();
-
-    return points;
-  }
 
   template <size_t NDim, concepts::queue TQueue>
-  inline clue::PointsHost<NDim> read_output(TQueue& queue, const std::string& file_path) {
-    std::fstream file(file_path);
-    if (!file.is_open()) {
-      throw std::runtime_error("Could not open file: " + file_path);
-    }
-    auto n_points =
-        std::count(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), '\n') -
-        1;
-    clue::PointsHost<NDim> points(queue, n_points);
+  inline clue::PointsHost<NDim> read_csv(TQueue& queue, const std::string& file_path);
 
-    file = std::fstream(file_path);
-    // discard the header
-    std::string buffer;
-    getline(file, buffer);
-    auto point_id = 0;
-    while (getline(file, buffer)) {
-      std::stringstream buffer_stream(buffer);
-      std::string value;
+  template <size_t NDim, concepts::queue TQueue>
+  inline clue::PointsHost<NDim> read_output(TQueue& queue, const std::string& file_path);
 
-      for (size_t dim = 0; dim < NDim; ++dim) {
-        getline(buffer_stream, value, ',');
-        points.coords(dim)[point_id] = std::stof(value);
-      }
-      getline(buffer_stream, value, ',');
-      points.weights()[point_id] = std::stof(value);
-      getline(buffer_stream, value, ',');
-      points.clusterIndexes()[point_id] = std::stoi(value);
-      getline(buffer_stream, value);
-      points.isSeed()[point_id] = std::stoi(value);
-
-      ++point_id;
-    }
-    file.close();
-
-    return points;
-  }
 }  // namespace clue
+
+#include "CLUEstering/utils/detail/read_csv.hpp"


### PR DESCRIPTION
This PR separates the declarations and definitions of the classes, functions and methods that are part of the public interface. The implementation details are hidden inside `detail` subfolders. This will be useful when implementing documentation for the C++ interface, and will allow the backend to remain sufficiently clean.