### PR TITLE
Provide `get_device` utility for choosing the device

### DIFF
--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
   auto avgIt = time_averages.begin();
   auto stdIt = time_stddevs.begin();
   auto sizeIt = sizes.begin();
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   std::ranges::for_each(
       std::views::iota(min) | std::views::take(range),
       [nruns, &device, &sizeIt, &avgIt, &stdIt](auto i) -> void {

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -8,8 +8,8 @@
 #include "CLUEstering/CLUEstering.hpp"
 
 void run(const std::string& input_file) {
-  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-  clue::Queue queue(dev_acc);
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
 
   auto h_points = clue::read_csv<2>(queue, input_file);
   clue::PointsDevice<2, clue::Device> d_points(queue, h_points.size());

--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -8,3 +8,4 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/utils/read_csv.hpp"
+#include "CLUEstering/utils/get_device.hpp"

--- a/include/CLUEstering/utils/get_device.hpp
+++ b/include/CLUEstering/utils/get_device.hpp
@@ -1,0 +1,13 @@
+
+#pragma once
+
+#include "CLUEstering/core/defines.hpp"
+#include <alpaka/alpaka.hpp>
+
+namespace clue {
+
+  inline clue::Device get_device(uint32_t device_id) {
+    return alpaka::getDevByIdx(clue::Platform{}, device_id);
+  }
+
+}  // namespace clue

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -9,8 +9,8 @@
 #include "doctest.h"
 
 TEST_CASE("Test make_cluster interfaces") {
-  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-  clue::Queue queue(dev_acc);
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/data_32768.csv");
   const auto n_points = h_points.size();

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -13,8 +13,8 @@
 
 TEST_CASE("Test clustering on benchmarking datasets") {
   for (auto i = 10; i < 19; ++i) {
-    const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-    clue::Queue queue(dev_acc);
+    const auto device = clue::get_device(0u);
+    clue::Queue queue(device);
 
     clue::PointsHost<2> h_points =
         clue::read_csv<2>(queue, fmt::format("../data/data_{}.csv", std::pow(2, i)));
@@ -39,8 +39,8 @@ TEST_CASE("Test clustering on benchmarking datasets") {
 }
 
 TEST_CASE("Test clustering on sissa") {
-  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-  clue::Queue queue(dev_acc);
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/sissa.csv");
   const auto n_points = h_points.size();
@@ -62,8 +62,8 @@ TEST_CASE("Test clustering on sissa") {
 }
 
 TEST_CASE("Test clustering on toy detector dataset") {
-  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-  clue::Queue queue(dev_acc);
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/toyDetector.csv");
   const auto n_points = h_points.size();
@@ -85,8 +85,8 @@ TEST_CASE("Test clustering on toy detector dataset") {
 }
 
 TEST_CASE("Test clustering on blob dataset") {
-  const auto dev_acc = alpaka::getDevByIdx(clue::Platform{}, 0u);
-  clue::Queue queue(dev_acc);
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
 
   clue::PointsHost<3> h_points = clue::read_csv<3>(queue, "../data/blob.csv");
   const auto n_points = h_points.size();

--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -5,6 +5,7 @@
 #include "CLUEstering/internal/alpaka/memory.hpp"
 #include "CLUEstering/internal/alpaka/work_division.hpp"
 #include "CLUEstering/internal/algorithm/algorithm.hpp"
+#include "CLUEstering/utils/get_device.hpp"
 
 #include <numeric>
 #include <ranges>
@@ -66,7 +67,7 @@ ALPAKA_FN_HOST bool compareDevicePoints(clue::Queue queue,
 }
 
 TEST_CASE("Test device points with internal allocation") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -81,7 +82,7 @@ TEST_CASE("Test device points with internal allocation") {
 }
 
 TEST_CASE("Test device points with external allocation of whole buffer") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -99,7 +100,7 @@ TEST_CASE("Test device points with external allocation of whole buffer") {
 }
 
 TEST_CASE("Test device points with external allocation passing the two buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -116,7 +117,7 @@ TEST_CASE("Test device points with external allocation passing the two buffers a
 }
 
 TEST_CASE("Test device points with external allocation passing four buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -136,7 +137,7 @@ TEST_CASE("Test device points with external allocation passing four buffers as p
 }
 
 TEST_CASE("Test extrema functions on device points column") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -159,7 +160,7 @@ TEST_CASE("Test extrema functions on device points column") {
 }
 
 TEST_CASE("Test reduction of device points column") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -1,6 +1,7 @@
 
 #include "CLUEstering/core/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
+#include "CLUEstering/utils/get_device.hpp"
 
 #include <numeric>
 #include <ranges>
@@ -10,7 +11,7 @@
 #include "doctest.h"
 
 TEST_CASE("Test host points with internal allocation") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -74,7 +75,7 @@ TEST_CASE("Test host points with internal allocation") {
 }
 
 TEST_CASE("Test host points with external allocation of whole buffer") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -140,7 +141,7 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as spans") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -208,7 +209,7 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as vectors") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -275,7 +276,7 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
 }
 
 TEST_CASE("Test host points with external allocation passing two buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -342,7 +343,7 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as spans") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -416,7 +417,7 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as vectors") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
@@ -485,7 +486,7 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
 }
 
 TEST_CASE("Test host points with external allocation passing four buffers as pointers") {
-  const auto device = alpaka::getDevByIdx(clue::Platform{}, 0u);
+  const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
   const uint32_t size = 1000;


### PR DESCRIPTION
This PR implements a `get_device` function that returns the alpaka device corresponding to a given index.
This is an alternative to using `alpaka::getDevByIdx` directly, and allows users to choose the device without having to use alpaka manually.