### PR TITLE
Add `clue::get_queue` utility 

### DIFF
--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -9,3 +9,4 @@
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/utils/read_csv.hpp"
 #include "CLUEstering/utils/get_device.hpp"
+#include "CLUEstering/utils/get_queue.hpp"

--- a/include/CLUEstering/core/detail/defines.hpp
+++ b/include/CLUEstering/core/detail/defines.hpp
@@ -1,0 +1,20 @@
+
+#pragma once
+
+#include "CLUEstering/internal/alpaka/config.hpp"
+
+namespace clue {
+
+  using Platform = ALPAKA_BACKEND::Platform;
+  using Device = ALPAKA_BACKEND::Device;
+  using Queue = ALPAKA_BACKEND::Queue;
+  using Event = ALPAKA_BACKEND::Event;
+
+  namespace internal {
+
+    using namespace alpaka_common;
+    using Acc = ALPAKA_BACKEND::Acc1D;
+
+  }  // namespace internal
+
+}  // namespace clue

--- a/include/CLUEstering/utils/get_device.hpp
+++ b/include/CLUEstering/utils/get_device.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/defines.hpp"
 #include <alpaka/alpaka.hpp>
 
 namespace clue {

--- a/include/CLUEstering/utils/get_queue.hpp
+++ b/include/CLUEstering/utils/get_queue.hpp
@@ -1,0 +1,22 @@
+
+#pragma once
+
+#include "CLUEstering/core/detail/defines.hpp"
+#include "CLUEstering/detail/concepts.hpp"
+#include <concepts>
+#include <alpaka/alpaka.hpp>
+
+namespace clue {
+
+  template <std::integral TIdx>
+  inline clue::Queue get_queue(TIdx device_id = TIdx{}) {
+    auto device = alpaka::getDevByIdx(clue::Platform{}, device_id);
+    return clue::Queue{device};
+  }
+
+  template <detail::concepts::device TDevice>
+  inline clue::Queue get_queue(const TDevice& device) {
+    return clue::Queue{device};
+  }
+
+}  // namespace clue

--- a/tests/association_map/build_map.hpp
+++ b/tests/association_map/build_map.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/AssociationMap.hpp"
 #include "CLUEstering/detail/concepts.hpp"
 #include "CLUEstering/internal/algorithm/extrema/extrema.hpp"

--- a/tests/test_association_map.cpp
+++ b/tests/test_association_map.cpp
@@ -1,7 +1,7 @@
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "association_map/build_map.hpp"
 

--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -1,5 +1,5 @@
 
-#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/internal/alpaka/memory.hpp"

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -1,5 +1,5 @@
 
-#include "CLUEstering/core/defines.hpp"
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/utils/get_device.hpp"
 

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -1,0 +1,60 @@
+
+#include "CLUEstering/CLUEstering.hpp"
+
+#include <cmath>
+#include <ranges>
+#include <span>
+#include <vector>
+
+#include "doctest.h"
+
+TEST_CASE("Test clue::get_device utility") {
+  clue::Device device = clue::get_device(0u);
+  static_assert(std::is_same_v<decltype(device), clue::Device>, "Expected type clue::Device");
+
+  const auto devices = alpaka::getDevs(clue::Platform{});
+  CHECK(devices[0u] == device);
+}
+
+TEST_CASE("Test clue::get_queue utility") {
+  SUBCASE("Create queue using device id") {
+    const auto dev_id1 = 0;
+    auto queue1 = clue::get_queue(dev_id1);
+    static_assert(std::is_same_v<decltype(queue1), clue::Queue>, "Expected type clue::Queue");
+    CHECK(alpaka::getDev(queue1) == alpaka::getDevByIdx(clue::Platform{}, dev_id1));
+
+    // test both signed and unsigned integer types
+    const auto dev_id2 = 0u;
+    auto queue2 = clue::get_queue(dev_id2);
+    static_assert(std::is_same_v<decltype(queue2), clue::Queue>, "Expected type clue::Queue");
+    CHECK(alpaka::getDev(queue2) == alpaka::getDevByIdx(clue::Platform{}, dev_id2));
+    CHECK(alpaka::getDev(queue2) == alpaka::getDev(queue1));
+
+    // check if data allocation works
+    clue::PointsHost<2> points1(queue1, 1000);
+    auto d_points1 = clue::PointsDevice<2, clue::Device>(queue1, points1.size());
+    clue::PointsHost<2> points2(queue2, 1000);
+    auto d_points2 = clue::PointsDevice<2, clue::Device>(queue2, points2.size());
+    CHECK(1);
+  }
+
+  SUBCASE("Create queue using device object") {
+    auto device = clue::get_device(0u);
+
+    auto queue1 = clue::get_queue(device);
+    static_assert(std::is_same_v<decltype(queue1), clue::Queue>, "Expected type clue::Queue");
+    CHECK(alpaka::getDev(queue1) == alpaka::getDevByIdx(clue::Platform{}, 0u));
+
+    auto queue2 = clue::get_queue(device);
+    static_assert(std::is_same_v<decltype(queue2), clue::Queue>, "Expected type clue::Queue");
+    CHECK(alpaka::getDev(queue2) == alpaka::getDevByIdx(clue::Platform{}, 0u));
+    CHECK(alpaka::getDev(queue2) == alpaka::getDev(queue1));
+
+    // check if data allocation works
+    clue::PointsHost<2> points1(queue1, 1000);
+    auto d_points1 = clue::PointsDevice<2, clue::Device>(queue1, points1.size());
+    clue::PointsHost<2> points2(queue2, 1000);
+    auto d_points2 = clue::PointsDevice<2, clue::Device>(queue2, points2.size());
+    CHECK(1);
+  }
+}


### PR DESCRIPTION
Following PR #156, this one adds `clue::get_queue`, a utility for obtaining a Queue given a device index or a Device object.
This again allows users to simplify the initial setup.