### PR TITLE
Default device template parameter of `PointsDevice` and `AssociationMap` to `clue::Device`

### DIFF
--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -19,7 +19,7 @@ void run(float dc,
 
   // Create the host and device points
   clue::PointsHost<Ndim> h_points(queue, n_points, std::get<0>(pData), std::get<1>(pData));
-  clue::PointsDevice<Ndim, clue::Device> d_points(queue, n_points);
+  clue::PointsDevice<Ndim> d_points(queue, n_points);
 
   algo.make_clusters(h_points, d_points, kernel, queue, block_size);
 }

--- a/benchmark/dataset_size/main.cpp
+++ b/benchmark/dataset_size/main.cpp
@@ -78,9 +78,7 @@ void to_csv(const TimeMeasures& measures, const std::string& filename) {
   file.close();
 }
 
-void run(clue::PointsHost<2>& h_points,
-         clue::PointsDevice<2, clue::Device>& d_points,
-         clue::Queue& queue) {
+void run(clue::PointsHost<2>& h_points, clue::PointsDevice<2>& d_points, clue::Queue& queue) {
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
@@ -117,7 +115,7 @@ int main(int argc, char* argv[]) {
 
         // Create the points host and device objects
         clue::PointsHost<2> h_points(queue, n_points);
-        clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
+        clue::PointsDevice<2> d_points(queue, n_points);
         clue::utils::generateRandomData<2>(h_points, 20, std::make_pair(-100.f, 100.f), 1.f);
 
         auto start = std::chrono::high_resolution_clock::now();

--- a/benchmark/profiling/main.cpp
+++ b/benchmark/profiling/main.cpp
@@ -12,7 +12,7 @@ void run(const std::string& input_file) {
   clue::Queue queue(device);
 
   auto h_points = clue::read_csv<2>(queue, input_file);
-  clue::PointsDevice<2, clue::Device> d_points(queue, h_points.size());
+  clue::PointsDevice<2> d_points(queue, h_points.size());
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);

--- a/include/CLUEstering/data_structures/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/AssociationMap.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/internal/Span.hpp"
 #include "CLUEstering/detail/concepts.hpp"
 #include "CLUEstering/internal/alpaka/config.hpp"
@@ -19,7 +20,7 @@ namespace clue {
 
   struct AssociationMapView;
 
-  template <concepts::device TDev>
+  template <concepts::device TDev = clue::Device>
   class AssociationMap {
   public:
     using key_type = int32_t;

--- a/include/CLUEstering/data_structures/PointsDevice.hpp
+++ b/include/CLUEstering/data_structures/PointsDevice.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/internal/PointsCommon.hpp"
 #include "CLUEstering/detail/concepts.hpp"
 #include "CLUEstering/internal/alpaka/memory.hpp"
@@ -14,7 +15,7 @@ namespace clue {
 
   namespace concepts = detail::concepts;
 
-  template <uint8_t Ndim, concepts::device TDev>
+  template <uint8_t Ndim, concepts::device TDev = clue::Device>
   class PointsDevice {
   public:
     template <concepts::queue TQueue>

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Test make_cluster interfaces") {
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/data_32768.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
+  clue::PointsDevice<2> d_points(queue, n_points);
 
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Test clustering on benchmarking datasets") {
     clue::PointsHost<2> h_points =
         clue::read_csv<2>(queue, fmt::format("../data/data_{}.csv", std::pow(2, i)));
     const auto n_points = h_points.size();
-    clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
+    clue::PointsDevice<2> d_points(queue, n_points);
 
     const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
     clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -44,7 +44,7 @@ TEST_CASE("Test clustering on sissa") {
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/sissa.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
+  clue::PointsDevice<2> d_points(queue, n_points);
 
   const float dc{20.f}, rhoc{10.f}, outlier{20.f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -67,7 +67,7 @@ TEST_CASE("Test clustering on toy detector dataset") {
 
   clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/toyDetector.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<2, clue::Device> d_points(queue, n_points);
+  clue::PointsDevice<2> d_points(queue, n_points);
 
   const float dc{4.5f}, rhoc{2.5f}, outlier{4.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
@@ -90,7 +90,7 @@ TEST_CASE("Test clustering on blob dataset") {
 
   clue::PointsHost<3> h_points = clue::read_csv<3>(queue, "../data/blob.csv");
   const auto n_points = h_points.size();
-  clue::PointsDevice<3, clue::Device> d_points(queue, n_points);
+  clue::PointsDevice<3> d_points(queue, n_points);
 
   const float dc{1.f}, rhoc{5.f}, outlier{2.f};
   clue::Clusterer<3> algo(queue, dc, rhoc, outlier);

--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -37,7 +37,7 @@ template <std::ranges::range TRange, uint8_t Ndim>
 ALPAKA_FN_HOST bool compareDevicePoints(clue::Queue queue,
                                         TRange&& h_coords,
                                         TRange&& h_weights,
-                                        clue::PointsDevice<Ndim, clue::Device>& d_points,
+                                        clue::PointsDevice<Ndim>& d_points,
                                         uint32_t size) {
   auto h_points = clue::PointsHost<Ndim>(queue, size);
   std::ranges::copy(h_coords, h_points.coords().begin());
@@ -71,7 +71,7 @@ TEST_CASE("Test device points with internal allocation") {
   clue::Queue queue(device);
 
   const uint32_t size = 1000;
-  clue::PointsDevice<2, clue::Device> d_points(queue, size);
+  clue::PointsDevice<2> d_points(queue, size);
 
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
   CHECK(compareDevicePoints(queue,
@@ -89,7 +89,7 @@ TEST_CASE("Test device points with external allocation of whole buffer") {
   const auto bytes = clue::soa::device::computeSoASize<2>(size);
   auto buffer = clue::make_device_buffer<std::byte[]>(queue, bytes);
 
-  clue::PointsDevice<2, clue::Device> d_points(queue, size, std::span(buffer.data(), bytes));
+  clue::PointsDevice<2> d_points(queue, size, std::span(buffer.data(), bytes));
 
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
   CHECK(compareDevicePoints(queue,
@@ -107,7 +107,7 @@ TEST_CASE("Test device points with external allocation passing the two buffers a
   auto input = clue::make_device_buffer<float[]>(queue, 3 * size);
   auto output = clue::make_device_buffer<int[]>(queue, 2 * size);
 
-  clue::PointsDevice<2, clue::Device> d_points(queue, size, input.data(), output.data());
+  clue::PointsDevice<2> d_points(queue, size, input.data(), output.data());
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
   CHECK(compareDevicePoints(queue,
                             std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float),
@@ -126,7 +126,7 @@ TEST_CASE("Test device points with external allocation passing four buffers as p
   auto cluster_ids = clue::make_device_buffer<int[]>(queue, size);
   auto b_isseed = clue::make_device_buffer<int[]>(queue, size);
 
-  clue::PointsDevice<2, clue::Device> d_points(
+  clue::PointsDevice<2> d_points(
       queue, size, coords.data(), weights.data(), cluster_ids.data(), b_isseed.data());
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
   CHECK(compareDevicePoints(queue,
@@ -148,7 +148,7 @@ TEST_CASE("Test extrema functions on device points column") {
   std::ranges::copy(data, h_points.coords().begin());
   std::ranges::copy(data, h_points.weights().begin());
 
-  clue::PointsDevice<2, clue::Device> d_points(queue, size);
+  clue::PointsDevice<2> d_points(queue, size);
   clue::copyToDevice(queue, d_points, h_points);
 
   auto max_it =
@@ -171,7 +171,7 @@ TEST_CASE("Test reduction of device points column") {
   std::ranges::copy(data, h_points.coords().begin());
   std::ranges::copy(data, h_points.weights().begin());
 
-  clue::PointsDevice<2, clue::Device> d_points(queue, size);
+  clue::PointsDevice<2> d_points(queue, size);
   clue::copyToDevice(queue, d_points, h_points);
 
   CHECK(clue::internal::algorithm::reduce(d_points.weight().begin(), d_points.weight().end()) ==

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -32,9 +32,9 @@ TEST_CASE("Test clue::get_queue utility") {
 
     // check if data allocation works
     clue::PointsHost<2> points1(queue1, 1000);
-    auto d_points1 = clue::PointsDevice<2, clue::Device>(queue1, points1.size());
+    auto d_points1 = clue::PointsDevice<2>(queue1, points1.size());
     clue::PointsHost<2> points2(queue2, 1000);
-    auto d_points2 = clue::PointsDevice<2, clue::Device>(queue2, points2.size());
+    auto d_points2 = clue::PointsDevice<2>(queue2, points2.size());
     CHECK(1);
   }
 
@@ -52,9 +52,9 @@ TEST_CASE("Test clue::get_queue utility") {
 
     // check if data allocation works
     clue::PointsHost<2> points1(queue1, 1000);
-    auto d_points1 = clue::PointsDevice<2, clue::Device>(queue1, points1.size());
+    auto d_points1 = clue::PointsDevice<2>(queue1, points1.size());
     clue::PointsHost<2> points2(queue2, 1000);
-    auto d_points2 = clue::PointsDevice<2, clue::Device>(queue2, points2.size());
+    auto d_points2 = clue::PointsDevice<2>(queue2, points2.size());
     CHECK(1);
   }
 }


### PR DESCRIPTION
Since the `ALPAKA_ACCELERATOR_NAMESPACE` has been removed in PR #151, now the template parameters for the `clue::PointsDevice` and `clue::AssociationMap` data structures can be easily defaulted to `clue::Device`.
This will make the interface cleaner for users.