### PR TITLE
Use reduce instead of extrema algorithms when calculating tiles

### DIFF
--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -60,16 +60,6 @@ namespace clue {
       setupPoints(h_points, dev_points, queue);
     }
 
-    void calculate_tile_size(CoordinateExtremes* min_max,
-                             float* tile_sizes,
-                             const PointsHost& h_points,
-                             int32_t nPerDim);
-    void calculate_tile_size(Queue& queue,
-                             CoordinateExtremes* min_max,
-                             float* tile_sizes,
-                             const PointsDevice& dev_points,
-                             uint32_t nPerDim);
-
     template <concepts::convolutional_kernel Kernel>
     void make_clusters_impl(PointsHost& h_points,
                             PointsDevice& dev_points,

--- a/include/CLUEstering/core/detail/ComputeTiles.hpp
+++ b/include/CLUEstering/core/detail/ComputeTiles.hpp
@@ -1,0 +1,76 @@
+
+#pragma once
+
+#include "CLUEstering/data_structures/PointsHost.hpp"
+#include "CLUEstering/data_structures/PointsDevice.hpp"
+#include "CLUEstering/data_structures/Tiles.hpp"
+#include "CLUEstering/internal/algorithm/algorithm.hpp"
+#include <algorithm>
+#include <execution>
+
+namespace clue {
+  namespace detail {
+
+    struct Max {
+      template <typename T>
+      ALPAKA_FN_HOST_ACC constexpr T operator()(const T& a, const T& b) const {
+        return std::max(a, b);
+      }
+    };
+
+    struct Min {
+      template <typename T>
+      ALPAKA_FN_HOST_ACC constexpr T operator()(const T& a, const T& b) const {
+        return std::min(a, b);
+      }
+    };
+
+    template <uint8_t Ndim>
+    void compute_tile_size(clue::CoordinateExtremes<Ndim>* min_max,
+                           float* tile_sizes,
+                           const clue::PointsHost<Ndim>& h_points,
+                           int32_t nPerDim) {
+      for (size_t dim{}; dim != Ndim; ++dim) {
+        auto coords = h_points.coords(dim);
+        const float dimMax = std::reduce(std::execution::unseq,
+                                         coords.begin(),
+                                         coords.end(),
+                                         std::numeric_limits<float>::lowest(),
+                                         Max{});
+        const float dimMin = std::reduce(std::execution::unseq,
+                                         coords.begin(),
+                                         coords.end(),
+                                         std::numeric_limits<float>::max(),
+                                         Min{});
+
+        min_max->min(dim) = dimMin;
+        min_max->max(dim) = dimMax;
+
+        const float tileSize = (dimMax - dimMin) / nPerDim;
+        tile_sizes[dim] = tileSize;
+      }
+    }
+
+    template <uint8_t Ndim>
+    void compute_tile_size(Queue& queue,
+                           clue::CoordinateExtremes<Ndim>* min_max,
+                           float* tile_sizes,
+                           const clue::PointsDevice<Ndim>& dev_points,
+                           uint32_t nPerDim) {
+      for (size_t dim{}; dim != Ndim; ++dim) {
+        auto coords = dev_points.coords(dim);
+        const auto dimMax = clue::internal::algorithm::reduce(
+            coords.begin(), coords.end(), std::numeric_limits<float>::lowest(), Max{});
+        const auto dimMin = clue::internal::algorithm::reduce(
+            coords.begin(), coords.end(), std::numeric_limits<float>::max(), Min{});
+
+        min_max->min(dim) = dimMin;
+        min_max->max(dim) = dimMax;
+
+        const float tileSize = (dimMax - dimMin) / nPerDim;
+        tile_sizes[dim] = tileSize;
+      }
+    }
+
+  }  // namespace detail
+}  // namespace clue


### PR DESCRIPTION
This PR uses `reduce` instead of `max/min_element` in the calculation of the tile sizes. It also changes the function from a method of the Clusterer to a free function.