### PR TITLE
Define default execution policy for internal use of std algorithms

### DIFF
--- a/include/CLUEstering/core/detail/ComputeTiles.hpp
+++ b/include/CLUEstering/core/detail/ComputeTiles.hpp
@@ -5,6 +5,7 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/internal/algorithm/algorithm.hpp"
+#include "CLUEstering/internal/algorithm/default_policy.hpp"
 #include <algorithm>
 #include <execution>
 
@@ -32,12 +33,12 @@ namespace clue {
                            int32_t nPerDim) {
       for (size_t dim{}; dim != Ndim; ++dim) {
         auto coords = h_points.coords(dim);
-        const float dimMax = std::reduce(std::execution::unseq,
+        const float dimMax = std::reduce(clue::internal::default_policy,
                                          coords.begin(),
                                          coords.end(),
                                          std::numeric_limits<float>::lowest(),
                                          Max{});
-        const float dimMin = std::reduce(std::execution::unseq,
+        const float dimMin = std::reduce(clue::internal::default_policy,
                                          coords.begin(),
                                          coords.end(),
                                          std::numeric_limits<float>::max(),

--- a/include/CLUEstering/internal/algorithm/default_policy.hpp
+++ b/include/CLUEstering/internal/algorithm/default_policy.hpp
@@ -1,0 +1,16 @@
+
+#pragma once
+
+#include <execution>
+
+namespace clue {
+  namespace internal {
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    inline constexpr auto default_policy = std::execution::par_unseq;
+#else
+    inline constexpr auto default_policy = std::execution::unseq;
+#endif
+
+  }  // namespace internal
+}  // namespace clue

--- a/include/CLUEstering/internal/algorithm/extrema/extrema.hpp
+++ b/include/CLUEstering/internal/algorithm/extrema/extrema.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "CLUEstering/internal/algorithm/default_policy.hpp"
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 #include <thrust/extrema.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -24,7 +26,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(oneapi::dpl::execution::dpcpp_default, first, last);
 #else
-        return std::min_element(first, last);
+        return std::min_element(default_policy, first, last);
 #endif
       }
 
@@ -54,7 +56,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(oneapi::dpl::execution::dpcpp_default, first, last, comp);
 #else
-        return std::min_element(first, last, comp);
+        return std::min_element(default_policy, first, last, comp);
 #endif
       }
 
@@ -84,7 +86,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(oneapi::dpl::execution::dpcpp_default, first, last);
 #else
-        return std::max_element(first, last);
+        return std::max_element(default_policy, first, last);
 #endif
       }
 
@@ -114,7 +116,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(oneapi::dpl::execution::dpcpp_default, first, last, comp);
 #else
-        return std::max_element(first, last, comp);
+        return std::max_element(default_policy, first, last, comp);
 #endif
       }
 
@@ -144,7 +146,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::minmax_element(oneapi::dpl::execution::dpcpp_default, first, last);
 #else
-        return std::minmax_element(first, last);
+        return std::minmax_element(default_policy, first, last);
 #endif
       }
 
@@ -173,7 +175,7 @@ namespace clue {
         return oneapi::dpl::minmax_element(
             oneapi::dpl::execution::dpcpp_default, first, last, comp);
 #else
-        return std::minmax_element(first, last, comp);
+        return std::minmax_element(default_policy, first, last, comp);
 #endif
       }
 

--- a/include/CLUEstering/internal/algorithm/reduce/reduce.hpp
+++ b/include/CLUEstering/internal/algorithm/reduce/reduce.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "CLUEstering/internal/algorithm/default_policy.hpp"
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 #include <thrust/reduce.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -24,7 +26,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last);
 #else
-        return std::reduce(first, last);
+        return std::reduce(default_policy, first, last);
 #endif
       }
 
@@ -51,7 +53,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last, init);
 #else
-        return std::reduce(first, last, init);
+        return std::reduce(default_policy, first, last, init);
 #endif
       }
 
@@ -83,7 +85,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last, init, op);
 #else
-        return std::reduce(first, last, init, op);
+        return std::reduce(default_policy, first, last, init, op);
 #endif
       }
 

--- a/include/CLUEstering/internal/algorithm/sort/sort.hpp
+++ b/include/CLUEstering/internal/algorithm/sort/sort.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "CLUEstering/internal/algorithm/default_policy.hpp"
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 #include <thrust/sort.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -25,7 +27,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default, first, last);
 #else
-        std::sort(first, last);
+        std::sort(default_policy, first, last);
 #endif
       }
 
@@ -55,7 +57,7 @@ namespace clue {
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default, first, last, comp);
 #else
-        std::sort(first, last, comp);
+        std::sort(default_policy, first, last, comp);
 #endif
       }
 


### PR DESCRIPTION
Currently the algorithms used internally use the `std::execution::unseq` policy. With this PR, a `default_policy` is defined, which expands to `std::execution::par_unseq` when the TBB backend is used, which assures that TBB will be linked in the final executable. This policy is also used in the CPU expansion of the internal algorithm wrappers.