### PR TITLE
Remove `is_seed` from public interface through `PointsHost`

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -18,7 +18,4 @@ int main() {
   algo.make_clusters(queue, h_points, d_points);
   // Read the data from the host points
   auto clusters_indexes = h_points.clusterIndexes();  // Get the cluster index for each points
-  auto seed_map =
-      h_points.isSeed();  // Obtain a boolean array indicating which points are the seeds
-                          // i.e. the cluster centers
 }

--- a/include/CLUEstering/data_structures/PointsDevice.hpp
+++ b/include/CLUEstering/data_structures/PointsDevice.hpp
@@ -89,12 +89,6 @@ namespace clue {
     /// @brief Returns the cluster indexes of the points as a span
     /// @return A span of the cluster indexes of the points
     ALPAKA_FN_HOST auto clusterIndexes();
-    /// @brief Returns the seed status of the points as a const span
-    /// @return A const span indicating whether each point is a seed
-    ALPAKA_FN_HOST auto isSeed() const;
-    /// @brief Returns the seed status of the points as a span
-    /// @return A span indicating whether each point is a seed
-    ALPAKA_FN_HOST auto isSeed();
     /// @brief Returns the view of the points
     /// @return A const reference to the PointsView structure containing the points data
     ALPAKA_FN_HOST const auto& view() const;
@@ -111,6 +105,9 @@ namespace clue {
 
     ALPAKA_FN_HOST auto nearestHigher() const;
     ALPAKA_FN_HOST auto nearestHigher();
+
+    ALPAKA_FN_HOST auto isSeed() const;
+    ALPAKA_FN_HOST auto isSeed();
 
   private:
     inline static constexpr uint8_t Ndim_ = Ndim;

--- a/include/CLUEstering/data_structures/PointsHost.hpp
+++ b/include/CLUEstering/data_structures/PointsHost.hpp
@@ -46,11 +46,11 @@ namespace clue {
     PointsHost(TQueue& queue, int32_t n_points, std::span<std::byte> buffer);
 
     template <concepts::queue TQueue, std::ranges::contiguous_range... TBuffers>
-      requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
+      requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 3)
     PointsHost(TQueue& queue, int32_t n_points, TBuffers&&... buffers);
 
     template <concepts::queue TQueue, concepts::contiguous_raw_data... TBuffers>
-      requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 4)
+      requires(sizeof...(TBuffers) == 2 || sizeof...(TBuffers) == 3)
     PointsHost(TQueue& queue, int32_t n_points, TBuffers... buffers);
 
     PointsHost(const PointsHost&) = delete;
@@ -89,12 +89,6 @@ namespace clue {
     /// @brief Returns the cluster indexes of the points as a span
     /// @return A span of the cluster indexes of the points
     ALPAKA_FN_HOST auto clusterIndexes();
-    /// @brief Returns the seed status of the points as a const span
-    /// @return A const span indicating whether each point is a seed
-    ALPAKA_FN_HOST auto isSeed() const;
-    /// @brief Returns the seed status of the points as a span
-    /// @return A span indicating whether each point is a seed
-    ALPAKA_FN_HOST auto isSeed();
     /// @brief Returns the view of the points
     /// @return A const reference to the PointsView structure containing the points data
     ALPAKA_FN_HOST const auto& view() const;

--- a/include/CLUEstering/data_structures/detail/PointsDevice.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsDevice.hpp
@@ -147,4 +147,13 @@ namespace clue {
     return std::span<int>(m_view.nearest_higher, m_size);
   }
 
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::isSeed() const {
+    return std::span<const int>(m_view.is_seed, m_size);
+  }
+  template <uint8_t Ndim, concepts::device TDev>
+  ALPAKA_FN_HOST inline auto PointsDevice<Ndim, TDev>::isSeed() {
+    return std::span<int>(m_view.is_seed, m_size);
+  }
+
 }  // namespace clue

--- a/include/CLUEstering/data_structures/internal/PointsCommon.hpp
+++ b/include/CLUEstering/data_structures/internal/PointsCommon.hpp
@@ -55,15 +55,6 @@ namespace clue {
         return std::span<int>(view.cluster_index, view.n);
       }
 
-      ALPAKA_FN_HOST auto isSeed() const {
-        auto& view = static_cast<const TPoints*>(this)->m_view;
-        return std::span<const int>(view.is_seed, view.n);
-      }
-      ALPAKA_FN_HOST auto isSeed() {
-        auto& view = static_cast<TPoints*>(this)->m_view;
-        return std::span<int>(view.is_seed, view.n);
-      }
-
       ALPAKA_FN_HOST const auto& view() const { return static_cast<const TPoints*>(this)->m_view; }
       ALPAKA_FN_HOST auto& view() { return static_cast<TPoints*>(this)->m_view; }
     };
@@ -105,10 +96,6 @@ namespace clue {
         queue,
         make_host_view(h_points.m_view.cluster_index, h_points.size()),
         make_device_view(alpaka::getDev(queue), d_points.m_view.cluster_index, h_points.size()));
-    alpaka::memcpy(
-        queue,
-        make_host_view(h_points.m_view.is_seed, h_points.size()),
-        make_device_view(alpaka::getDev(queue), d_points.m_view.is_seed, h_points.size()));
   }
   template <concepts::queue TQueue, uint8_t Ndim, concepts::device TDev>
   void copyToDevice(TQueue& queue,

--- a/include/CLUEstering/utils/detail/read_csv.hpp
+++ b/include/CLUEstering/utils/detail/read_csv.hpp
@@ -73,8 +73,6 @@ namespace clue {
       points.weights()[point_id] = std::stof(value);
       getline(buffer_stream, value, ',');
       points.clusterIndexes()[point_id] = std::stoi(value);
-      getline(buffer_stream, value);
-      points.isSeed()[point_id] = std::stoi(value);
 
       ++point_id;
     }

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -22,32 +22,25 @@ TEST_CASE("Test make_cluster interfaces") {
 
   const auto truth_data = clue::read_output<2>(queue, "../data/truth_files/data_32768_truth.csv");
   auto truth_ids = truth_data.clusterIndexes();
-  auto truth_isSeed = truth_data.isSeed();
   SUBCASE("Run clustering without passing device points") {
     algo.make_clusters(queue, h_points, clue::FlatKernel{.5f}, block_size);
     auto clusters = h_points.clusterIndexes();
-    auto isSeed = h_points.isSeed();
 
     CHECK(clue::validate_results(clusters, truth_ids));
-    CHECK(std::ranges::equal(truth_isSeed, isSeed));
   }
 
   SUBCASE("Run clustering without passing the queue") {
     algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, block_size);
     auto clusters = h_points.clusterIndexes();
-    auto isSeed = h_points.isSeed();
 
     CHECK(clue::validate_results(clusters, truth_ids));
-    CHECK(std::ranges::equal(truth_isSeed, isSeed));
   }
 
   SUBCASE("Run clustering without passing the queue and device points") {
     algo.make_clusters(h_points, clue::FlatKernel{.5f}, block_size);
     auto clusters = h_points.clusterIndexes();
-    auto isSeed = h_points.isSeed();
 
     CHECK(clue::validate_results(clusters, truth_ids));
-    CHECK(std::ranges::equal(truth_isSeed, isSeed));
   }
   SUBCASE("Run clustering from device points") {
     clue::copyToDevice(queue, d_points, h_points);
@@ -55,10 +48,8 @@ TEST_CASE("Test make_cluster interfaces") {
     clue::copyToHost(queue, h_points, d_points);
 
     auto clusters = h_points.clusterIndexes();
-    auto isSeed = h_points.isSeed();
 
     CHECK(clue::validate_results(clusters, truth_ids));
-    CHECK(std::ranges::equal(truth_isSeed, isSeed));
   }
 }
 

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -32,14 +32,11 @@ TEST_CASE("Test clustering on benchmarking datasets") {
 
     algo.make_clusters(queue, h_points, d_points);
     auto clusters = h_points.clusterIndexes();
-    auto isSeed = h_points.isSeed();
 
     const auto truth_data = clue::read_output<2>(
         queue, fmt::format("../data/truth_files/data_{}_truth.csv", std::pow(2, i)));
     auto truth_ids = truth_data.clusterIndexes();
-    auto truth_isSeed = truth_data.isSeed();
     CHECK(clue::validate_results(clusters, truth_ids));
-    CHECK(std::ranges::equal(truth_isSeed, isSeed));
   }
 }
 
@@ -56,13 +53,10 @@ TEST_CASE("Test clustering on sissa") {
 
   algo.make_clusters(queue, h_points, d_points);
   auto clusters = h_points.clusterIndexes();
-  auto isSeed = h_points.isSeed();
 
   const auto truth_data = clue::read_output<2>(queue, "../data/truth_files/sissa_1000_truth.csv");
   auto truth_ids = truth_data.clusterIndexes();
-  auto truth_isSeed = truth_data.isSeed();
   CHECK(clue::validate_results(clusters, truth_ids));
-  CHECK(std::ranges::equal(truth_isSeed, isSeed));
 }
 
 TEST_CASE("Test clustering on toy detector dataset") {
@@ -78,13 +72,10 @@ TEST_CASE("Test clustering on toy detector dataset") {
 
   algo.make_clusters(queue, h_points, d_points);
   auto clusters = h_points.clusterIndexes();
-  auto isSeed = h_points.isSeed();
 
   const auto truth_data = clue::read_output<2>(queue, "../data/truth_files/toy_det_1000_truth.csv");
   auto truth_ids = truth_data.clusterIndexes();
-  auto truth_isSeed = truth_data.isSeed();
   CHECK(clue::validate_results(clusters, truth_ids));
-  CHECK(std::ranges::equal(truth_isSeed, isSeed));
 }
 
 TEST_CASE("Test clustering on blob dataset") {
@@ -100,11 +91,8 @@ TEST_CASE("Test clustering on blob dataset") {
 
   algo.make_clusters(queue, h_points, d_points);
   auto clusters = h_points.clusterIndexes();
-  auto isSeed = h_points.isSeed();
 
   const auto truth_data = clue::read_output<3>(queue, "../data/truth_files/blobs_truth.csv");
   auto truth_ids = truth_data.clusterIndexes();
-  auto truth_isSeed = truth_data.isSeed();
   CHECK(clue::validate_results(clusters, truth_ids));
-  CHECK(std::ranges::equal(truth_isSeed, isSeed));
 }

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -24,18 +24,15 @@ TEST_CASE("Test host points with internal allocation") {
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -43,25 +40,21 @@ TEST_CASE("Test host points with internal allocation") {
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -71,7 +64,6 @@ TEST_CASE("Test host points with internal allocation") {
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -90,18 +82,15 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -109,25 +98,21 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -137,7 +122,6 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -158,18 +142,15 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -177,25 +158,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -205,7 +182,6 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -225,18 +201,15 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -244,25 +217,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -272,7 +241,6 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -292,18 +260,15 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -311,25 +276,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -339,7 +300,6 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -351,14 +311,12 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
   std::vector<float> coords(2 * size);
   std::vector<float> weights(size);
   std::vector<int> cluster_ids(size);
-  std::vector<int> v_isseed(size);
 
   clue::PointsHost<2> h_points(queue,
                                size,
                                std::span(coords.data(), coords.size()),
                                std::span(weights.data(), weights.size()),
-                               std::span(cluster_ids.data(), cluster_ids.size()),
-                               std::span(v_isseed.data(), v_isseed.size()));
+                               std::span(cluster_ids.data(), cluster_ids.size()));
   auto view = h_points.view();
 
   CHECK(view.n == size);
@@ -366,18 +324,15 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -385,25 +340,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -413,7 +364,6 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -425,9 +375,8 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
   std::vector<float> coords(2 * size);
   std::vector<float> weights(size);
   std::vector<int> cluster_ids(size);
-  std::vector<int> v_isseed(size);
 
-  clue::PointsHost<2> h_points(queue, size, coords, weights, cluster_ids, v_isseed);
+  clue::PointsHost<2> h_points(queue, size, coords, weights, cluster_ids);
   auto view = h_points.view();
 
   CHECK(view.n == size);
@@ -435,18 +384,15 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -454,25 +400,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -482,7 +424,6 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -494,10 +435,8 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
   std::vector<float> coords(2 * size);
   std::vector<float> weights(size);
   std::vector<int> cluster_ids(size);
-  std::vector<int> v_isseed(size);
 
-  clue::PointsHost<2> h_points(
-      queue, size, coords.data(), weights.data(), cluster_ids.data(), v_isseed.data());
+  clue::PointsHost<2> h_points(queue, size, coords.data(), weights.data(), cluster_ids.data());
   auto view = h_points.view();
 
   CHECK(view.n == size);
@@ -505,18 +444,15 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
     auto coords = h_points.coords();
     auto weights = h_points.weights();
     auto cluster_indexes = h_points.clusterIndexes();
-    auto is_seed = h_points.isSeed();
 
     std::iota(coords.begin(), coords.end(), 0.f);
     std::fill(weights.begin(), weights.end(), 1.f);
     std::iota(cluster_indexes.begin(), cluster_indexes.end(), 0);
-    std::fill(is_seed.begin(), is_seed.end(), 0);
 
     // compare with content of the view
     CHECK(std::ranges::equal(coords, std::span<float>(view.coords, 2 * size)));
     CHECK(std::ranges::equal(weights, std::span<float>(view.weight, size)));
     CHECK(std::ranges::equal(cluster_indexes, std::span<int>(view.cluster_index, size)));
-    CHECK(std::ranges::equal(is_seed, std::span<int>(view.is_seed, size)));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -524,25 +460,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
         coords, std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float)));
     CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
-    std::ranges::for_each(is_seed, [](auto x) { CHECK(x == 0); });
   }
 
   SUBCASE("Set from view") {
     auto coords = view.coords;
     auto weights = view.weight;
     auto cluster_indexes = view.cluster_index;
-    auto is_seed = view.is_seed;
 
     std::iota(coords, coords + 2 * size, 2000.f);
     std::fill(weights, weights + size, 2.f);
     std::iota(cluster_indexes, cluster_indexes + size, 2000);
-    std::fill(is_seed, is_seed + size, 3);
 
     // compare with content of the view
     CHECK(std::ranges::equal(std::span(coords, 2 * size), h_points.coords()));
     CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
     CHECK(std::ranges::equal(std::span(cluster_indexes, size), h_points.clusterIndexes()));
-    CHECK(std::ranges::equal(std::span(is_seed, size), h_points.isSeed()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -552,7 +484,6 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
     CHECK(std::ranges::equal(std::span(cluster_indexes, size),
                              std::views::iota(2000) | std::views::take(size)));
     std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
-    std::ranges::for_each(std::span(is_seed, size), [](auto x) { CHECK(x == 3); });
   }
 }
 
@@ -564,7 +495,6 @@ TEST_CASE("Test point accessor") {
   std::iota(points.coords().begin(), points.coords().end(), 0.f);
   std::fill(points.weights().begin(), points.weights().end(), 1.f);
   std::iota(points.clusterIndexes().begin(), points.clusterIndexes().end(), 0);
-  std::fill(points.isSeed().begin(), points.isSeed().end(), 0);
 
   SUBCASE("Test point methods") {
     auto point = points[0];


### PR DESCRIPTION
The seed is an implementation detail, so users are more likely then not, not interested in it. What is usually more interesting is the cluster centroid, which will be featured in PR #184. Furthermore, this requires users passing externally allocated data to the points to also pass a buffer for `is_seed`, which they probably don't have.
So, this PR removes the buffer from the public interface.