### PR TITLE
Only compile for cuda architectures from `sm75` onwards

### DIFF
--- a/CLUEstering/BindingModules/cuda/CMakeLists.txt
+++ b/CLUEstering/BindingModules/cuda/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(
   CLUE_GPU_CUDA
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY
              ${CMAKE_CURRENT_BINARY_DIR}/../../../lib/CLUEstering/lib/
-             CUDA_ARCHITECTURES "50;60;61;62;70;80;90")
+             CUDA_ARCHITECTURES "75;80;90")
 # copy shared library for local testing
 add_custom_command(
   TARGET CLUE_GPU_CUDA

--- a/benchmark/dataset_size/cuda/CMakeLists.txt
+++ b/benchmark/dataset_size/cuda/CMakeLists.txt
@@ -17,6 +17,5 @@ target_link_libraries(cuda.out PRIVATE ${pybind_link})
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                             CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
-set_target_properties(
-  cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
-                                                    "50;60;61;62;70;80;90")
+set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+                                          CUDA_ARCHITECTURES "75;80;90")

--- a/benchmark/profiling/cuda/CMakeLists.txt
+++ b/benchmark/profiling/cuda/CMakeLists.txt
@@ -15,6 +15,5 @@ target_include_directories(
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                             CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
-set_target_properties(
-  cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
-                                                    "50;60;61;62;70;80;90")
+set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+                                          CUDA_ARCHITECTURES "75;80;90")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -47,9 +47,8 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLED)
     add_executable(cuda.out main.cpp)
     target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED)
     target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
-    set_target_properties(
-      cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
-                                                        "50;60;61;62;70;80;90")
+    set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+                                              CUDA_ARCHITECTURES "75;80;90")
   else()
     message(FATAL_ERROR "CUDA not found. Please install it.")
   endif()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -19,6 +19,5 @@ target_include_directories(
 target_compile_definitions(cuda.out PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
                                             CLUE_ENABLE_CACHING_ALLOCATOR)
 target_compile_options(cuda.out PRIVATE --expt-relaxed-constexpr)
-set_target_properties(
-  cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
-                                                    "50;60;61;62;70;80;90")
+set_target_properties(cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+                                          CUDA_ARCHITECTURES "75;80;90")


### PR DESCRIPTION
Both internally, as well as during the installation of the Python library, we were still building the CUDA backend for old cuda capabilities (50, 60, ...). Now we only compile for `sm_75/80/90`