### PR TITLE
Set nearest higher to `-1` for confirmed seeds

### DIFF
--- a/include/CLUEstering/core/detail/CLUEAlpakaKernels.hpp
+++ b/include/CLUEstering/core/detail/CLUEAlpakaKernels.hpp
@@ -215,6 +215,7 @@ namespace clue {
 
           if (is_seed) {
             dev_points.is_seed[i] = 1;
+            dev_points.nearest_higher[i] = -1;
             seeds->push_back(acc, i);
           } else {
             dev_points.is_seed[i] = 0;

--- a/include/CLUEstering/core/detail/Clusterer.hpp
+++ b/include/CLUEstering/core/detail/Clusterer.hpp
@@ -275,11 +275,11 @@ namespace clue {
         queue, work_division, m_tiles->view(), dev_points.view(), kernel, m_dc, n_points);
     detail::computeNearestHighers<Acc>(
         queue, work_division, m_tiles->view(), dev_points.view(), m_dm, n_points);
+    detail::findClusterSeeds<Acc>(
+        queue, work_division, m_seeds->data(), dev_points.view(), m_seed_dc, m_rhoc, n_points);
 
     m_followers->template fill<Acc>(queue, dev_points);
 
-    detail::findClusterSeeds<Acc>(
-        queue, work_division, m_seeds->data(), dev_points.view(), m_seed_dc, m_rhoc, n_points);
     detail::assignPointsToClusters<Acc>(
         queue, block_size, m_seeds->data(), m_followers->view(), dev_points.view());
 
@@ -302,11 +302,11 @@ namespace clue {
         queue, work_division, m_tiles->view(), dev_points.view(), kernel, m_dc, n_points);
     detail::computeNearestHighers<Acc>(
         queue, work_division, m_tiles->view(), dev_points.view(), m_dm, n_points);
+    detail::findClusterSeeds<Acc>(
+        queue, work_division, m_seeds->data(), dev_points.view(), m_seed_dc, m_rhoc, n_points);
 
     m_followers->template fill<Acc>(queue, dev_points);
 
-    detail::findClusterSeeds<Acc>(
-        queue, work_division, m_seeds->data(), dev_points.view(), m_seed_dc, m_rhoc, n_points);
     detail::assignPointsToClusters<Acc>(
         queue, block_size, m_seeds->data(), m_followers->view(), dev_points.view());
 


### PR DESCRIPTION
From this PR, when a point is marked as a seed its nearest higher is set to `-1`, and the `Followers` associator is filled after this kernel has completed. This prevents some seeds to be included in the cluster of a very near seed.