### PR TITLE
Implement `make_associator` functions in internal namespace

### DIFF
--- a/include/CLUEstering/data_structures/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/AssociationMap.hpp
@@ -15,10 +15,11 @@
 
 namespace clue {
 
-  namespace test {
-    template <concepts::queue _TQueue>
-    auto build_map(_TQueue&, std::span<const int32_t>, int32_t);
-  }
+  namespace internal {
+    template <clue::concepts::queue TQueue>
+    auto make_associator(TQueue& queue, std::span<int32_t> associations, int32_t elements);
+    auto make_associator(std::span<int32_t> associations, int32_t elements);
+  }  // namespace internal
 
   /// @brief The AssociationMap class is a data structure that maps keys to values.
   /// It associates integer keys with integer values in ono-to-many or many-to-many associations.
@@ -191,8 +192,8 @@ namespace clue {
     friend class TilesAlpaka;
 
     template <concepts::queue _TQueue>
-    friend auto clue::test::build_map(_TQueue&, std::span<key_type>, int32_t);
-    friend auto clue::test::build_map(std::span<int32_t> associations, int32_t elements);
+    friend auto clue::internal::make_associator(_TQueue&, std::span<key_type>, int32_t);
+    friend auto clue::internal::make_associator(std::span<int32_t> associations, int32_t elements);
   };
 
   using host_associator = AssociationMap<alpaka::DevCpu>;

--- a/include/CLUEstering/data_structures/internal/MakeAssociator.hpp
+++ b/include/CLUEstering/data_structures/internal/MakeAssociator.hpp
@@ -8,10 +8,10 @@
 #include <limits>
 #include <span>
 
-namespace clue::test {
+namespace clue::internal {
 
   template <clue::concepts::queue TQueue>
-  inline auto build_map(TQueue& queue, std::span<int32_t> associations, int32_t elements) {
+  inline auto make_associator(TQueue& queue, std::span<int32_t> associations, int32_t elements) {
     const auto bins = *clue::internal::algorithm::max_element(
                           associations.data(), associations.data() + associations.size()) +
                       1;
@@ -20,7 +20,7 @@ namespace clue::test {
     return map;
   }
 
-  inline auto build_map(std::span<int32_t> associations, int32_t elements) {
+  inline auto make_associator(std::span<int32_t> associations, int32_t elements) {
     const auto bins = std::reduce(associations.data(),
                                   associations.data() + associations.size(),
                                   std::numeric_limits<int32_t>::lowest(),
@@ -31,4 +31,4 @@ namespace clue::test {
     return map;
   }
 
-}  // namespace clue::test
+}  // namespace clue::internal

--- a/tests/test_association_map.cpp
+++ b/tests/test_association_map.cpp
@@ -3,7 +3,7 @@
 
 #include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
-#include "association_map/build_map.hpp"
+#include "CLUEstering/data_structures/internal/MakeAssociator.hpp"
 
 #include <numeric>
 #include <ranges>
@@ -20,7 +20,8 @@ TEST_CASE("Test binary association map") {
   auto associations = clue::make_host_buffer<int32_t[]>(queue, size);
   std::ranges::transform(
       std::views::iota(0, size), associations.data(), [](auto x) -> int32_t { return x % 2 == 0; });
-  auto map = clue::test::build_map(queue, std::span<int32_t>(associations.data(), size), size);
+  auto map =
+      clue::internal::make_associator(queue, std::span<int32_t>(associations.data(), size), size);
 
   SUBCASE("Check size") { CHECK(map.size() == 2); }
   SUBCASE("Check extents") {
@@ -63,10 +64,12 @@ TEST_CASE("Test throwing conditions") {
       std::views::iota(0, size), associations.data(), [](auto x) -> int32_t { return x % 2 == 0; });
 
   SUBCASE("Test construction throwing conditions") {
-    CHECK_THROWS(clue::test::build_map(queue, std::span<int32_t>(associations.data(), 0), 0));
+    CHECK_THROWS(
+        clue::internal::make_associator(queue, std::span<int32_t>(associations.data(), 0), 0));
   }
 
-  auto map = clue::test::build_map(queue, std::span<int32_t>(associations.data(), size), size);
+  auto map =
+      clue::internal::make_associator(queue, std::span<int32_t>(associations.data(), size), size);
   SUBCASE("Test count throwing conditions") {
     CHECK_THROWS(map.count(-1));
     CHECK_THROWS(map.count(2));
@@ -94,7 +97,7 @@ TEST_CASE("Test throwing conditions") {
   }
 
   const auto const_map =
-      clue::test::build_map(queue, std::span<int32_t>(associations.data(), size), size);
+      clue::internal::make_associator(queue, std::span<int32_t>(associations.data(), size), size);
   SUBCASE("Test lower_bound throwing conditions") {
     CHECK_THROWS(map.lower_bound(-1));
     CHECK_THROWS(map.lower_bound(2));
@@ -118,7 +121,7 @@ TEST_CASE("Test binary host_associator") {
   auto associations = clue::make_host_buffer<int32_t[]>(size);
   std::ranges::transform(
       std::views::iota(0, size), associations.data(), [](auto x) -> int32_t { return x % 2 == 0; });
-  auto map = clue::test::build_map(std::span<int32_t>(associations.data(), size), size);
+  auto map = clue::internal::make_associator(std::span<int32_t>(associations.data(), size), size);
 
   SUBCASE("Check size") { CHECK(map.size() == 2); }
   SUBCASE("Check extents") {


### PR DESCRIPTION
This PR implements internal functions `make_associator` that build association maps for internal use. This substitutes the `build_map` methods that were restricted for use in tests, making them usable in the whole backend.