### PR TITLE
Remove throwing check on negative access to points coordinates

### DIFF
--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -190,7 +190,6 @@ TEST_CASE("Test coordinate getter throwing conditions") {
     const uint32_t size = 1000;
     auto queue = clue::get_queue(0u);
     clue::PointsHost<2> points(queue, size);
-    CHECK_THROWS(points.coords(-5));
     CHECK_THROWS(points.coords(3));
     CHECK_THROWS(points.coords(10));
   }
@@ -198,7 +197,6 @@ TEST_CASE("Test coordinate getter throwing conditions") {
     const uint32_t size = 1000;
     auto queue = clue::get_queue(0u);
     const clue::PointsDevice<2> points(queue, size);
-    CHECK_THROWS(points.coords(-5));
     CHECK_THROWS(points.coords(3));
     CHECK_THROWS(points.coords(10));
   }

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -592,7 +592,6 @@ TEST_CASE("Test coordinate getter throwing conditions") {
     const uint32_t size = 1000;
     auto queue = clue::get_queue(0u);
     clue::PointsHost<2> points(queue, size);
-    CHECK_THROWS(points.coords(-5));
     CHECK_THROWS(points.coords(3));
     CHECK_THROWS(points.coords(10));
   }
@@ -600,7 +599,6 @@ TEST_CASE("Test coordinate getter throwing conditions") {
     const uint32_t size = 1000;
     auto queue = clue::get_queue(0u);
     const clue::PointsHost<2> points(queue, size);
-    CHECK_THROWS(points.coords(-5));
     CHECK_THROWS(points.coords(3));
     CHECK_THROWS(points.coords(10));
   }


### PR DESCRIPTION
Following PR #215, since there the dimensionality of the points is unsigned, it makes no sense to check for the access with a negative value. For this reason the check is removed.