### PR TITLE
Feature device version of `get_clusters`

### DIFF
--- a/include/CLUEstering/CLUEstering.hpp
+++ b/include/CLUEstering/CLUEstering.hpp
@@ -11,6 +11,7 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/utils/read_csv.hpp"
+#include "CLUEstering/utils/cluster_centroid.hpp"
+#include "CLUEstering/utils/get_clusters.hpp"
 #include "CLUEstering/utils/get_device.hpp"
 #include "CLUEstering/utils/get_queue.hpp"
-#include "CLUEstering/utils/cluster_centroid.hpp"

--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -8,13 +8,13 @@
 #include "CLUEstering/core/ConvolutionalKernel.hpp"
 #include "CLUEstering/core/detail/ClusteringKernels.hpp"
 #include "CLUEstering/core/detail/defines.hpp"
+#include "CLUEstering/data_structures/AssociationMap.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/Tiles.hpp"
 #include "CLUEstering/data_structures/internal/Followers.hpp"
 
 #include <cstdint>
-#include <vector>
 
 namespace clue {
 
@@ -204,9 +204,15 @@ namespace clue {
 
     /// @brief Get the clusters from the host points
     ///
-    /// @param h_points Host points to cluster
-    /// @return A vector of clusters, where each cluster is a vector of point indices
+    /// @param h_points Host points
+    /// @return An associator mapping clusters and points
     host_associator getClusters(const PointsHost& h_points);
+    /// @brief Get the clusters from the device points
+    /// This function returns an associator object mapping the clusters to the points they contain.
+    ///
+    /// @param d_points Device points
+    /// @return An associator mapping clusters and points
+    AssociationMap<Device> getClusters(Queue& queue, const PointsDevice& d_points);
   };
 
 }  // namespace clue

--- a/include/CLUEstering/core/detail/Clusterer.hpp
+++ b/include/CLUEstering/core/detail/Clusterer.hpp
@@ -165,7 +165,13 @@ namespace clue {
 
   template <std::size_t Ndim>
   inline host_associator Clusterer<Ndim>::getClusters(const PointsHost& h_points) {
-    return clue::get_clusters(h_points.clusterIndexes());
+    return clue::get_clusters(h_points);
+  }
+
+  template <std::size_t Ndim>
+  inline AssociationMap<Device> Clusterer<Ndim>::getClusters(Queue& queue,
+                                                             const PointsDevice& d_points) {
+    return clue::get_clusters(queue, d_points);
   }
 
   template <std::size_t Ndim>

--- a/include/CLUEstering/utils/detail/cluster_centroid.hpp
+++ b/include/CLUEstering/utils/detail/cluster_centroid.hpp
@@ -15,7 +15,7 @@ namespace clue {
   inline Centroid<Ndim> cluster_centroid(const clue::PointsHost<Ndim>& points,
                                          std::size_t cluster_id) {
     auto cluster_ids = points.clusterIndexes();
-    auto clusters = get_clusters(cluster_ids);
+    auto clusters = get_clusters(points);
     // TODO: add error handling
     Centroid<Ndim> centroid;
     auto size = clusters.count(cluster_id);
@@ -39,7 +39,7 @@ namespace clue {
   template <std::size_t Ndim>
   inline Centroids<Ndim> cluster_centroids(const clue::PointsHost<Ndim>& points) {
     auto cluster_ids = points.clusterIndexes();
-    auto clusters = get_clusters(cluster_ids);
+    auto clusters = get_clusters(points);
     const auto n_clusters = clusters.size();
 
     Centroids<Ndim> centroids(n_clusters);

--- a/include/CLUEstering/utils/detail/get_clusters.hpp
+++ b/include/CLUEstering/utils/detail/get_clusters.hpp
@@ -1,0 +1,33 @@
+
+#pragma once
+
+#include "CLUEstering/utils/get_clusters.hpp"
+#include "CLUEstering/data_structures/internal/MakeAssociator.hpp"
+#include <span>
+
+namespace clue {
+  namespace detail {
+
+    inline auto get_clusters(std::span<const int> cluster_ids) {
+      return internal::make_associator(cluster_ids, static_cast<int32_t>(cluster_ids.size()));
+    }
+
+    template <concepts::queue TQueue>
+    inline auto get_clusters(TQueue& queue, std::span<const int> cluster_ids) {
+      return internal::make_associator(
+          queue, cluster_ids, static_cast<int32_t>(cluster_ids.size()));
+    }
+
+  }  // namespace detail
+
+  template <std::size_t Ndim>
+  inline host_associator get_clusters(const PointsHost<Ndim>& points) {
+    return detail::get_clusters(points.clusterIndexes());
+  }
+
+  template <concepts::queue TQueue, std::size_t Ndim>
+  inline host_associator get_clusters(TQueue& queue, const PointsDevice<Ndim>& points) {
+    return detail::get_clusters(queue, points.clusterIndexes());
+  }
+
+}  // namespace clue

--- a/include/CLUEstering/utils/get_clusters.hpp
+++ b/include/CLUEstering/utils/get_clusters.hpp
@@ -3,17 +3,16 @@
 
 #include "CLUEstering/data_structures/AssociationMap.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
-#include "CLUEstering/data_structures/internal/MakeAssociator.hpp"
+#include "CLUEstering/data_structures/PointsDevice.hpp"
 
 namespace clue {
 
-  inline host_associator get_clusters(std::span<const int> cluster_ids) {
-    return internal::make_associator(cluster_ids, cluster_ids.size());
-  }
-
   template <std::size_t Ndim>
-  inline host_associator get_clusters(const PointsHost<Ndim>& points) {
-    return get_clusters(points.clusterIndexes(), static_cast<int32_t>(points.size()));
-  }
+  inline host_associator get_clusters(const PointsHost<Ndim>& points);
+
+  template <concepts::queue TQueue, std::size_t Ndim>
+  inline host_associator get_clusters(TQueue& queue, const PointsDevice<Ndim>& points);
 
 }  // namespace clue
+
+#include "CLUEstering/utils/detail/get_clusters.hpp"

--- a/include/CLUEstering/utils/validation.hpp
+++ b/include/CLUEstering/utils/validation.hpp
@@ -3,7 +3,7 @@
 
 #include "CLUEstering/data_structures/AssociationMap.hpp"
 #include "CLUEstering/data_structures/internal/MakeAssociator.hpp"
-#include "CLUEstering/utils/get_clusters.hpp"
+#include "CLUEstering/utils/detail/get_clusters.hpp"
 #include <algorithm>
 #include <ranges>
 #include <span>
@@ -21,7 +21,7 @@ namespace clue {
 
   inline std::vector<int> compute_clusters_size(std::span<const int> cluster_ids) {
     const auto nclusters = compute_nclusters(cluster_ids);
-    const auto clusters_points = get_clusters(cluster_ids);
+    const auto clusters_points = detail::get_clusters(cluster_ids);
 
     std::vector<int> clusters(nclusters);
     std::ranges::transform(std::views::iota(0, nclusters), clusters.begin(), [&](int i) {

--- a/tests/test_cluster_centroid.cpp
+++ b/tests/test_cluster_centroid.cpp
@@ -39,6 +39,6 @@ TEST_CASE("Test computation of all cluster centroids") {
 
   algo.make_clusters(queue, h_points, d_points);
   auto centroids = clue::cluster_centroids(h_points);
-  auto clusters = clue::compute_clusters_points(h_points.clusterIndexes());
+  auto clusters = clue::get_clusters(h_points);
   CHECK(centroids.size() == clusters.size());
 }

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -1,5 +1,6 @@
 
 #include "CLUEstering/CLUEstering.hpp"
+#include "CLUEstering/utils/validation.hpp"
 
 #include <cmath>
 #include <ranges>

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -1,5 +1,6 @@
 
 #include "CLUEstering/CLUEstering.hpp"
+#include "CLUEstering/utils/validation.hpp"
 
 #include <cmath>
 #include <ranges>

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Test clue::get_queue utility") {
   }
 }
 
-TEST_CASE("Test validation utilities") {
+TEST_CASE("Test get_clusters host function") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
@@ -70,5 +70,19 @@ TEST_CASE("Test validation utilities") {
   const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
   algo.make_clusters(queue, h_points, d_points);
-  auto clusters = clue::compute_clusters_points(h_points.clusterIndexes());
+  auto clusters = clue::get_clusters(h_points);
+}
+
+TEST_CASE("Test get_clusters device function") {
+  const auto device = clue::get_device(0u);
+  clue::Queue queue(device);
+
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/data_32768.csv");
+  const auto n_points = h_points.size();
+  clue::PointsDevice<2> d_points(queue, n_points);
+
+  const float dc{1.5f}, rhoc{10.f}, outlier{1.5f};
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
+  algo.make_clusters(queue, h_points, d_points);
+  auto clusters = clue::get_clusters(queue, d_points);
 }


### PR DESCRIPTION
This PR implements another version of `getClusters` that takes a `Queue` and `PointsDevice`, and returns a device associator mapping clusters to points.
We also expose free functions `get_clusters`.