### PR TITLE
Use `std::views::take` in points tests

### DIFF
--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -79,11 +79,12 @@ TEST_CASE("Test device points with internal allocation") {
   clue::PointsDevice<2> d_points(queue, size);
 
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
-  CHECK(compareDevicePoints(queue,
-                            std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float),
-                            std::views::iota(0, (int)(size)) | std::views::transform(to_float),
-                            d_points,
-                            size));
+  CHECK(compareDevicePoints(
+      queue,
+      std::views::iota(0) | std::views::take(2 * size) | std::views::transform(to_float),
+      std::views::iota(0) | std::views::take(size) | std::views::transform(to_float),
+      d_points,
+      size));
 }
 
 TEST_CASE("Test device points with external allocation of whole buffer") {
@@ -97,11 +98,12 @@ TEST_CASE("Test device points with external allocation of whole buffer") {
   clue::PointsDevice<2> d_points(queue, size, std::span(buffer.data(), bytes));
 
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
-  CHECK(compareDevicePoints(queue,
-                            std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float),
-                            std::views::iota(0, (int)(size)) | std::views::transform(to_float),
-                            d_points,
-                            size));
+  CHECK(compareDevicePoints(
+      queue,
+      std::views::iota(0) | std::views::take(2 * size) | std::views::transform(to_float),
+      std::views::iota(0) | std::views::take(size) | std::views::transform(to_float),
+      d_points,
+      size));
 }
 
 TEST_CASE("Test device points with external allocation passing the two buffers as pointers") {
@@ -114,11 +116,12 @@ TEST_CASE("Test device points with external allocation passing the two buffers a
 
   clue::PointsDevice<2> d_points(queue, size, input.data(), output.data());
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
-  CHECK(compareDevicePoints(queue,
-                            std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float),
-                            std::views::iota(0, (int)(size)) | std::views::transform(to_float),
-                            d_points,
-                            size));
+  CHECK(compareDevicePoints(
+      queue,
+      std::views::iota(0) | std::views::take(2 * size) | std::views::transform(to_float),
+      std::views::iota(0) | std::views::take(size) | std::views::transform(to_float),
+      d_points,
+      size));
 }
 
 TEST_CASE("Test device points with external allocation passing four buffers as pointers") {
@@ -132,11 +135,12 @@ TEST_CASE("Test device points with external allocation passing four buffers as p
 
   clue::PointsDevice<2> d_points(queue, size, coords.data(), weights.data(), cluster_ids.data());
   auto to_float = [](int i) -> float { return static_cast<float>(i); };
-  CHECK(compareDevicePoints(queue,
-                            std::views::iota(0, (int)(2 * size)) | std::views::transform(to_float),
-                            std::views::iota(0, (int)(size)) | std::views::transform(to_float),
-                            d_points,
-                            size));
+  CHECK(compareDevicePoints(
+      queue,
+      std::views::iota(0) | std::views::take(2 * size) | std::views::transform(to_float),
+      std::views::iota(0) | std::views::take(size) | std::views::transform(to_float),
+      d_points,
+      size));
 }
 
 TEST_CASE("Test extrema functions on device points column") {

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -36,9 +36,9 @@ TEST_CASE("Test host points with internal allocation") {
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -94,9 +94,9 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -154,9 +154,9 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -213,9 +213,9 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -272,9 +272,9 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -336,9 +336,9 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -396,9 +396,9 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 
@@ -456,9 +456,9 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
-    CHECK(std::ranges::equal(coords,
-                             std::views::iota(0, (int)(size)) | std::views::transform(to_float)));
-    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0, (int)size)));
+    CHECK(std::ranges::equal(
+        coords, std::views::iota(0) | std::views::take(size) | std::views::transform(to_float)));
+    CHECK(std::ranges::equal(cluster_indexes, std::views::iota(0) | std::views::take(size)));
     std::ranges::for_each(weights, [](auto x) { CHECK(x == 1.f); });
   }
 


### PR DESCRIPTION
This PR fixes tests of host and device points which are failing to compile on some CUDA configurations due to an overload of `std::views::iota`