### PR TITLE
Disable thrust algorithms when compiling with `ALPAKA_HOST_ONLY`

### DIFF
--- a/include/CLUEstering/internal/algorithm/extrema/extrema.hpp
+++ b/include/CLUEstering/internal/algorithm/extrema/extrema.hpp
@@ -2,8 +2,12 @@
 #pragma once
 
 #include "CLUEstering/internal/algorithm/default_policy.hpp"
+#include <alpaka/alpaka.hpp>
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
+#include <thrust/extrema.h>
+#include <thrust/execution_policy.h>
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
 #include <thrust/extrema.h>
 #include <thrust/execution_policy.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -20,9 +24,9 @@ namespace clue {
       template <typename ForwardIterator>
       ALPAKA_FN_HOST inline constexpr ForwardIterator min_element(ForwardIterator first,
                                                                   ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(thrust::device, first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(thrust::hip::par, first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(oneapi::dpl::execution::dpcpp_default, first, last);
@@ -35,9 +39,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr ForwardIterator min_element(ExecutionPolicy&& policy,
                                                                   ForwardIterator first,
                                                                   ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(std::forward<ExecutionPolicy>(policy), first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(std::forward<ExecutionPolicy>(policy), first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(std::forward<ExecutionPolicy>(policy), first, last);
@@ -50,9 +54,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr ForwardIterator min_element(ForwardIterator first,
                                                                   ForwardIterator last,
                                                                   BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(thrust::device, first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(thrust::hip::par, first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(oneapi::dpl::execution::dpcpp_default, first, last, comp);
@@ -66,9 +70,9 @@ namespace clue {
                                                                   ForwardIterator first,
                                                                   ForwardIterator last,
                                                                   BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::min_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::min_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
@@ -80,9 +84,9 @@ namespace clue {
       template <typename ForwardIterator>
       ALPAKA_FN_HOST inline constexpr ForwardIterator max_element(ForwardIterator first,
                                                                   ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(thrust::device, first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(thrust::hip::par, first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(oneapi::dpl::execution::dpcpp_default, first, last);
@@ -95,9 +99,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr ForwardIterator max_element(ExecutionPolicy&& policy,
                                                                   ForwardIterator first,
                                                                   ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(std::forward<ExecutionPolicy>(policy), first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(std::forward<ExecutionPolicy>(policy), first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(std::forward<ExecutionPolicy>(policy), first, last);
@@ -110,9 +114,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr ForwardIterator max_element(ForwardIterator first,
                                                                   ForwardIterator last,
                                                                   BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(thrust::device, first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(thrust::hip::par, first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(oneapi::dpl::execution::dpcpp_default, first, last, comp);
@@ -126,9 +130,9 @@ namespace clue {
                                                                   ForwardIterator first,
                                                                   ForwardIterator last,
                                                                   BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::max_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::max_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
@@ -140,9 +144,9 @@ namespace clue {
       template <typename ForwardIterator>
       ALPAKA_FN_HOST inline constexpr std::pair<ForwardIterator, ForwardIterator> minmax_element(
           ForwardIterator first, ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(thrust::device, first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(thrust::hip::par, first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::minmax_element(oneapi::dpl::execution::dpcpp_default, first, last);
@@ -154,9 +158,9 @@ namespace clue {
       template <typename ExecutionPolicy, typename ForwardIterator>
       ALPAKA_FN_HOST inline constexpr std::pair<ForwardIterator, ForwardIterator> minmax_element(
           ExecutionPolicy&& policy, ForwardIterator first, ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(std::forward<ExecutionPolicy>(policy), first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(std::forward<ExecutionPolicy>(policy), first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::minmax_element(std::forward<ExecutionPolicy>(policy), first, last);
@@ -168,9 +172,9 @@ namespace clue {
       template <typename ForwardIterator, typename BinaryPredicate>
       ALPAKA_FN_HOST inline constexpr std::pair<ForwardIterator, ForwardIterator> minmax_element(
           ForwardIterator first, ForwardIterator last, BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(thrust::device, first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(thrust::hip::par, first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::minmax_element(
@@ -186,9 +190,9 @@ namespace clue {
           ForwardIterator first,
           ForwardIterator last,
           BinaryPredicate comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::minmax_element(std::forward<ExecutionPolicy>(policy), first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::minmax_element(

--- a/include/CLUEstering/internal/algorithm/reduce/reduce.hpp
+++ b/include/CLUEstering/internal/algorithm/reduce/reduce.hpp
@@ -2,8 +2,12 @@
 #pragma once
 
 #include "CLUEstering/internal/algorithm/default_policy.hpp"
+#include <alpaka/alpaka.hpp>
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
+#include <thrust/reduce.h>
+#include <thrust/execution_policy.h>
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
 #include <thrust/reduce.h>
 #include <thrust/execution_policy.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -20,9 +24,9 @@ namespace clue {
       template <typename InputIterator>
       ALPAKA_FN_HOST inline constexpr typename std::iterator_traits<InputIterator>::value_type
       reduce(InputIterator first, InputIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::device, first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::hip::par, first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last);
@@ -34,9 +38,9 @@ namespace clue {
       template <typename ExecutionPolicy, typename ForwardIterator>
       ALPAKA_FN_HOST inline constexpr typename std::iterator_traits<ForwardIterator>::value_type
       reduce(ExecutionPolicy&& policy, ForwardIterator first, ForwardIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(std::forward<ExecutionPolicy>(policy), first, last);
@@ -47,9 +51,9 @@ namespace clue {
 
       template <typename InputIterator, typename T>
       ALPAKA_FN_HOST inline constexpr T reduce(InputIterator first, InputIterator last, T init) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::device, first, last, init);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::hip::par, first, last, init);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last, init);
@@ -63,9 +67,9 @@ namespace clue {
                                                ForwardIterator first,
                                                ForwardIterator last,
                                                T init) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last, init);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last, init);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(std::forward<ExecutionPolicy>(policy), first, last, init);
@@ -79,9 +83,9 @@ namespace clue {
                                                InputIterator last,
                                                T init,
                                                BinaryOperation op) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::device, first, last, init, op);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(thrust::hip::par, first, last, init, op);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(oneapi::dpl::execution::dpcpp_default, first, last, init, op);
@@ -99,9 +103,9 @@ namespace clue {
                                                ForwardIterator last,
                                                T init,
                                                BinaryOperation op) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last, init, op);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         return thrust::reduce(std::forward<ExecutionPolicy>(policy), first, last, init, op);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         return oneapi::dpl::reduce(std::forward<ExecutionPolicy>(policy), first, last, init, op);

--- a/include/CLUEstering/internal/algorithm/sort/sort.hpp
+++ b/include/CLUEstering/internal/algorithm/sort/sort.hpp
@@ -3,8 +3,12 @@
 #pragma once
 
 #include "CLUEstering/internal/algorithm/default_policy.hpp"
+#include <alpaka/alpaka.hpp>
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
+#include <thrust/sort.h>
+#include <thrust/execution_policy.h>
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
@@ -21,9 +25,9 @@ namespace clue {
       template <typename RandomAccessIterator>
       ALPAKA_FN_HOST inline constexpr void sort(RandomAccessIterator first,
                                                 RandomAccessIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(thrust::device, first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(thrust::hip::par, first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default, first, last);
@@ -36,9 +40,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr void sort(ExecutionPolicy&& policy,
                                                 RandomAccessIterator first,
                                                 RandomAccessIterator last) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(std::forward<ExecutionPolicy>(policy), first, last);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(std::forward<ExecutionPolicy>(policy), first, last);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(std::forward<ExecutionPolicy>(policy), first, last);
@@ -51,9 +55,9 @@ namespace clue {
       ALPAKA_FN_HOST inline constexpr void sort(RandomAccessIterator first,
                                                 RandomAccessIterator last,
                                                 Compare comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(thrust::device, first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(thrust::hip::par, first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(oneapi::dpl::execution::dpcpp_default, first, last, comp);
@@ -67,9 +71,9 @@ namespace clue {
                                                 RandomAccessIterator first,
                                                 RandomAccessIterator last,
                                                 Compare comp) {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(std::forward<ExecutionPolicy>(policy), first, last, comp);
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) and not defined(ALPAKA_HOST_ONLY)
         thrust::sort(std::forward<ExecutionPolicy>(policy), first, last, comp);
 #elif defined(ALPAKA_ACC_SYCL_ENABLED)
         oneapi::dpl::sort(std::forward<ExecutionPolicy>(policy), first, last, comp);


### PR DESCRIPTION
Applications in CMSSW showed that when a file includes shared object compiled with CUDA/HIP, which uses then thrust algorithm, and is compiled with the `ALPAKA_HOST_ONLY` flag, the thrust system macros get disabled and this causes the overload substitutio of the algorithms to fail. For this reason, the headers are only included when the flag is not enabled.