### PR TITLE
Mark device-only functions as `ALPAKA_FN_ACC`

### DIFF
--- a/include/CLUEstering/core/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/ConvolutionalKernel.hpp
@@ -28,7 +28,7 @@ namespace clue {
     /// @param j The index of the second point
     /// @return The computed kernel value
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const;
+    ALPAKA_FN_ACC float operator()(const TAcc&, float /*dist_ij*/, int point_id, int j) const;
   };
 
   /// @brief The GaussianKernel class implements a Gaussian kernel for convolution.
@@ -55,7 +55,7 @@ namespace clue {
     /// @param j The index of the second point
     /// @return The computed kernel value
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
+    ALPAKA_FN_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
   };
 
   /// @brief The ExponentialKernel class implements an exponential kernel for convolution.
@@ -80,7 +80,7 @@ namespace clue {
     /// @param j The index of the second point
     /// @return The computed kernel value
     template <typename TAcc>
-    ALPAKA_FN_HOST_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
+    ALPAKA_FN_ACC float operator()(const TAcc& acc, float dist_ij, int point_id, int j) const;
   };
 
 }  // namespace clue

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -34,16 +34,16 @@ namespace clue::detail {
   }
 
   template <typename TAcc, std::size_t Ndim, std::size_t N_, concepts::convolutional_kernel KernelType>
-  ALPAKA_FN_HOST_ACC void for_recursion(const TAcc& acc,
-                                        VecArray<int32_t, Ndim>& base_vec,
-                                        const clue::SearchBoxBins<Ndim>& search_box,
-                                        internal::TilesView<Ndim>& tiles,
-                                        PointsView<Ndim>& dev_points,
-                                        const KernelType& kernel,
-                                        const std::array<float, Ndim>& coords_i,
-                                        float* rho_i,
-                                        const DistanceParameter<Ndim>& dc,
-                                        int32_t point_id) {
+  ALPAKA_FN_ACC void for_recursion(const TAcc& acc,
+                                   VecArray<int32_t, Ndim>& base_vec,
+                                   const clue::SearchBoxBins<Ndim>& search_box,
+                                   internal::TilesView<Ndim>& tiles,
+                                   PointsView<Ndim>& dev_points,
+                                   const KernelType& kernel,
+                                   const std::array<float, Ndim>& coords_i,
+                                   float* rho_i,
+                                   const DistanceParameter<Ndim>& dc,
+                                   int32_t point_id) {
     if constexpr (N_ == 0) {
       auto binId = tiles.getGlobalBinByBin(base_vec);
       auto binSize = tiles[binId].size();
@@ -104,17 +104,17 @@ namespace clue::detail {
   };
 
   template <typename TAcc, std::size_t Ndim, std::size_t N_>
-  ALPAKA_FN_HOST_ACC void for_recursion_nearest_higher(const TAcc& acc,
-                                                       VecArray<int32_t, Ndim>& base_vec,
-                                                       const clue::SearchBoxBins<Ndim>& search_box,
-                                                       internal::TilesView<Ndim>& tiles,
-                                                       PointsView<Ndim>& dev_points,
-                                                       const std::array<float, Ndim>& coords_i,
-                                                       float rho_i,
-                                                       float* delta_i,
-                                                       int* nh_i,
-                                                       const DistanceParameter<Ndim>& dm,
-                                                       int32_t point_id) {
+  ALPAKA_FN_ACC void for_recursion_nearest_higher(const TAcc& acc,
+                                                  VecArray<int32_t, Ndim>& base_vec,
+                                                  const clue::SearchBoxBins<Ndim>& search_box,
+                                                  internal::TilesView<Ndim>& tiles,
+                                                  PointsView<Ndim>& dev_points,
+                                                  const std::array<float, Ndim>& coords_i,
+                                                  float rho_i,
+                                                  float* delta_i,
+                                                  int* nh_i,
+                                                  const DistanceParameter<Ndim>& dm,
+                                                  int32_t point_id) {
     if constexpr (N_ == 0) {
       int binId = tiles.getGlobalBinByBin(base_vec);
       int binSize = tiles[binId].size();

--- a/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
@@ -15,10 +15,10 @@ namespace clue {
   }
 
   template <typename TAcc>
-  inline ALPAKA_FN_HOST_ACC float FlatKernel::operator()(const TAcc&,
-                                                         float /*dist_ij*/,
-                                                         int point_id,
-                                                         int j) const {
+  inline ALPAKA_FN_ACC float FlatKernel::operator()(const TAcc&,
+                                                    float /*dist_ij*/,
+                                                    int point_id,
+                                                    int j) const {
     if (point_id == j) {
       return 1.f;
     } else {
@@ -34,10 +34,10 @@ namespace clue {
   }
 
   template <typename TAcc>
-  inline ALPAKA_FN_HOST_ACC float GaussianKernel::operator()(const TAcc& acc,
-                                                             float dist_ij,
-                                                             int point_id,
-                                                             int j) const {
+  inline ALPAKA_FN_ACC float GaussianKernel::operator()(const TAcc& acc,
+                                                        float dist_ij,
+                                                        int point_id,
+                                                        int j) const {
     if (point_id == j) {
       return 1.f;
     } else {
@@ -55,10 +55,10 @@ namespace clue {
   }
 
   template <typename TAcc>
-  inline ALPAKA_FN_HOST_ACC float ExponentialKernel::operator()(const TAcc& acc,
-                                                                float dist_ij,
-                                                                int point_id,
-                                                                int j) const {
+  inline ALPAKA_FN_ACC float ExponentialKernel::operator()(const TAcc& acc,
+                                                           float dist_ij,
+                                                           int point_id,
+                                                           int j) const {
     if (point_id == j) {
       return 1.f;
     } else {

--- a/include/CLUEstering/data_structures/internal/TilesView.hpp
+++ b/include/CLUEstering/data_structures/internal/TilesView.hpp
@@ -87,7 +87,7 @@ namespace clue::internal {
       return clue::Span<int32_t>{buf_ptr, size};
     }
 
-    ALPAKA_FN_HOST_ACC inline constexpr float normalizeCoordinate(float coord, int dim) const {
+    ALPAKA_FN_ACC inline constexpr float normalizeCoordinate(float coord, int dim) const {
       const float range = minmax->range(dim);
       float remainder = coord - static_cast<int>(coord / range) * range;
       if (remainder >= minmax->max(dim))


### PR DESCRIPTION
Some functions were still marked as `ALPAKA_FN_HOST_ACC` even though whey were only used on the device. Marking them as `ALPAKA_FN_ACC` will decrease (though slightly) the compilation times.