### PR TITLE
Memcpy columns separately in `copyToDevice`

### DIFF
--- a/include/CLUEstering/data_structures/detail/PointsConversion.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsConversion.hpp
@@ -4,6 +4,7 @@
 
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
+#include "CLUEstering/internal/meta/apply.hpp"
 #include "CLUEstering/detail/concepts.hpp"
 #include <alpaka/alpaka.hpp>
 
@@ -24,11 +25,12 @@ namespace clue {
   inline void copyToDevice(TQueue& queue,
                            PointsDevice<Ndim, TDev>& d_points,
                            const PointsHost<Ndim>& h_points) {
-    // TODO: copy each coordinate column separately
-    alpaka::memcpy(
-        queue,
-        make_device_view(alpaka::getDev(queue), d_points.m_view.coords[0], Ndim * h_points.size()),
-        make_host_view(h_points.m_view.coords[0], Ndim * h_points.size()));
+    meta::apply<Ndim>([&]<std::size_t Dim> {
+      alpaka::memcpy(
+          queue,
+          make_device_view(alpaka::getDev(queue), d_points.m_view.coords[Dim], h_points.size()),
+          make_host_view(h_points.m_view.coords[Dim], Ndim * h_points.size()));
+    });
     alpaka::memcpy(queue,
                    make_device_view(alpaka::getDev(queue), d_points.m_view.weight, h_points.size()),
                    make_host_view(h_points.m_view.weight, h_points.size()));


### PR DESCRIPTION
After PR #226, in `copyToDevice` we must copy all the columns separately.