### PR TITLE
Add path suffixes in file path inside `to_csv` if absent

### DIFF
--- a/CLUEstering/CLUEstering.py
+++ b/CLUEstering/CLUEstering.py
@@ -1219,6 +1219,10 @@ class clusterer:
         None
         """
 
+        if output_folder[-1] != '/':
+            output_folder += '/'
+        if file_name[-4:] != '.csv':
+            file_name += '.csv' 
         out_path = output_folder + file_name
         data = {}
         for i in range(self.clust_data.n_dim):


### PR DESCRIPTION
In the `to_csv` method of the Python interface, this PR adds the `/` to `output_folder` and `.csv` to `file_name` if the user doesn't.