### PR TITLE
Fix extents returned by AssociationMap

### DIFF
--- a/include/CLUEstering/data_structures/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/AssociationMap.hpp
@@ -175,7 +175,7 @@ namespace clue {
     device_buffer<TDev, mapped_type[]> m_indexes;
     device_buffer<TDev, key_type[]> m_offsets;
     AssociationMapView m_view;
-    size_type m_nbins;
+    Extents m_extents;
 
     ALPAKA_FN_HOST void initialize(size_type nelements, size_type nbins)
       requires std::same_as<TDev, alpaka::DevCpu>;

--- a/include/CLUEstering/data_structures/AssociationMapView.hpp
+++ b/include/CLUEstering/data_structures/AssociationMapView.hpp
@@ -20,8 +20,8 @@ namespace clue {
   class AssociationMapView {
   public:
     struct Extents {
-      std::size_t values;
       std::size_t keys;
+      std::size_t values;
     };
 
   private:

--- a/tests/test_association_map.cpp
+++ b/tests/test_association_map.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Test binary association map") {
   SUBCASE("Check size") { CHECK(map.size() == 2); }
   SUBCASE("Check extents") {
     CHECK(map.extents().values == size);
-    CHECK(map.extents().keys == 3);
+    CHECK(map.extents().keys == 2);
   }
   SUBCASE("Test contains") {
     CHECK(map.contains(0));
@@ -136,7 +136,7 @@ TEST_CASE("Test binary host_associator") {
   SUBCASE("Check size") { CHECK(map.size() == 2); }
   SUBCASE("Check extents") {
     CHECK(map.extents().values == size);
-    CHECK(map.extents().keys == 3);
+    CHECK(map.extents().keys == 2);
   }
   SUBCASE("Test contains") {
     CHECK(map.contains(0));


### PR DESCRIPTION
The `AssociationMap::extents` method was returning the elements allocated in the containers, including the padding, rather than the actual elements inside. This PR fixes this by saving the sizes in the map instead of computing them on-the-fly.