### PR TITLE
Remove deprecated overload of `make_clusters`

### DIFF
--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -156,18 +156,6 @@ namespace clue {
                        PointsDevice& dev_points,
                        const Kernel& kernel = FlatKernel{.5f},
                        std::size_t block_size = 256);
-    /// @brief Construct the clusters from host and device points
-    ///
-    /// @param h_points Host points to cluster
-    /// @param dev_points Device points to cluster
-    /// @param kernel The convolutional kernel to use for computing the local densities, default is FlatKernel with height 0.5
-    /// @param block_size The size of the blocks to use for clustering, default is 256
-    /// @note This method creates a temporary queue for the operations on the device
-    template <concepts::convolutional_kernel Kernel = FlatKernel>
-    void make_clusters(PointsHost& h_points,
-                       PointsDevice& dev_points,
-                       const Kernel& kernel = FlatKernel{.5f},
-                       std::size_t block_size = 256);
     /// @brief Construct the clusters from device points
     ///
     /// @param queue The queue to use for the device operations

--- a/include/CLUEstering/core/detail/Clusterer.hpp
+++ b/include/CLUEstering/core/detail/Clusterer.hpp
@@ -131,20 +131,6 @@ namespace clue {
   }
   template <std::size_t Ndim>
   template <concepts::convolutional_kernel Kernel>
-  inline void Clusterer<Ndim>::make_clusters(PointsHost& h_points,
-                                             PointsDevice& dev_points,
-                                             const Kernel& kernel,
-                                             std::size_t block_size) {
-    auto device = alpaka::getDevByIdx(Platform{}, 0u);
-    Queue queue(device);
-    init_device(queue);
-
-    setup(queue, h_points, dev_points);
-    make_clusters_impl(h_points, dev_points, kernel, queue, block_size);
-    alpaka::wait(queue);
-  }
-  template <std::size_t Ndim>
-  template <concepts::convolutional_kernel Kernel>
   inline void Clusterer<Ndim>::make_clusters(Queue& queue,
                                              PointsDevice& dev_points,
                                              const Kernel& kernel,

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -29,13 +29,6 @@ TEST_CASE("Test make_cluster interfaces") {
     CHECK(clue::validate_results(h_points, truth));
   }
 
-  SUBCASE("Run clustering without passing the queue") {
-    algo.make_clusters(h_points, d_points, clue::FlatKernel{.5f}, block_size);
-    auto clusters = h_points.clusterIndexes();
-
-    CHECK(clue::validate_results(h_points, truth));
-  }
-
   SUBCASE("Run clustering without passing the queue and device points") {
     algo.make_clusters(h_points, clue::FlatKernel{.5f}, block_size);
 


### PR DESCRIPTION
This overload of `make_clusters` is not useful, because if users created a `PointsDevice` object, that means that they also created a queue.