### PR TITLE
Fix offset check during tiles setup

### DIFF
--- a/include/CLUEstering/core/detail/SetupTiles.hpp
+++ b/include/CLUEstering/core/detail/SetupTiles.hpp
@@ -32,8 +32,8 @@ namespace clue::detail {
       tiles = std::make_optional<internal::Tiles<Ndim, TDev>>(queue, points.size(), ntiles);
     }
     // check if tiles are large enough for current data
-    if (!(tiles->extents().values >= static_cast<std::size_t>(points.size())) or
-        !(tiles->extents().keys >= static_cast<std::size_t>(ntiles))) {
+    if ((tiles->extents().values < static_cast<std::size_t>(points.size())) or
+        (tiles->extents().keys < static_cast<std::size_t>(ntiles))) {
       tiles->initialize(points.size(), ntiles, n_per_dim, queue);
     } else {
       tiles->reset(points.size(), ntiles, n_per_dim);
@@ -65,8 +65,8 @@ namespace clue::detail {
       tiles = std::make_optional<internal::Tiles<Ndim, TDev>>(queue, points.size(), ntiles);
     }
     // check if tiles are large enough for current data
-    if (!(tiles->extents().values >= static_cast<std::size_t>(points.size())) or
-        !(tiles->extents().keys >= static_cast<std::size_t>(ntiles))) {
+    if ((tiles->extents().values < static_cast<std::size_t>(points.size())) or
+        (tiles->extents().keys < static_cast<std::size_t>(ntiles))) {
       tiles->initialize(points.size(), ntiles, n_per_dim, queue);
     } else {
       tiles->reset(points.size(), ntiles, n_per_dim);

--- a/include/CLUEstering/data_structures/detail/AssociationMap.hpp
+++ b/include/CLUEstering/data_structures/detail/AssociationMap.hpp
@@ -247,7 +247,7 @@ namespace clue {
                                                               size_type nbins,
                                                               TQueue& queue) {
     m_indexes = make_device_buffer<int32_t[]>(queue, nelements);
-    m_offsets = make_device_buffer<int32_t[]>(queue, nbins);
+    m_offsets = make_device_buffer<int32_t[]>(queue, nbins + 1);
     m_extents = {nbins, nelements};
 
     m_view.m_indexes = m_indexes.data();


### PR DESCRIPTION
address the corner case in which the next event has one point more than the previous; it was crashing with the current logic.