### PR TITLE
Move math functions to `clue::math` namespace

### DIFF
--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -46,7 +46,7 @@ namespace clue::detail {
           distance += distance_vector[dim] * distance_vector[dim];
         }
 
-        auto k = kernel(acc, clue::internal::math::sqrt(distance), point_id, j);
+        auto k = kernel(acc, math::sqrt(distance), point_id, j);
         rho_i += static_cast<int>(distance_vector <= dc) * k * dev_points.weight[j];
       }
       return;

--- a/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
+++ b/include/CLUEstering/core/detail/ConvolutionalKernel.hpp
@@ -41,9 +41,8 @@ namespace clue {
     if (point_id == j) {
       return 1.f;
     } else {
-      return m_gaus_amplitude *
-             clue::internal::math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
-                                       (2 * m_gaus_std * m_gaus_std));
+      return m_gaus_amplitude * math::exp(-(dist_ij - m_gaus_avg) * (dist_ij - m_gaus_avg) /
+                                          (2 * m_gaus_std * m_gaus_std));
     }
   }
 
@@ -62,7 +61,7 @@ namespace clue {
     if (point_id == j) {
       return 1.f;
     } else {
-      return (m_exp_amplitude * clue::internal::math::exp(-m_exp_avg * dist_ij));
+      return (m_exp_amplitude * math::exp(-m_exp_avg * dist_ij));
     }
   }
 

--- a/include/CLUEstering/data_structures/internal/TilesView.hpp
+++ b/include/CLUEstering/data_structures/internal/TilesView.hpp
@@ -43,8 +43,8 @@ namespace clue::internal {
       }
 
       // Address the cases of underflow and overflow
-      coord_bin = internal::math::min(coord_bin, nperdim - 1);
-      coord_bin = internal::math::max(coord_bin, 0);
+      coord_bin = math::min(coord_bin, nperdim - 1);
+      coord_bin = math::max(coord_bin, 0);
 
       return coord_bin;
     }
@@ -52,8 +52,8 @@ namespace clue::internal {
     ALPAKA_FN_ACC inline constexpr int getGlobalBin(const float* coords) const {
       int global_bin = 0;
       for (auto dim = 0u; dim != Ndim - 1; ++dim) {
-        global_bin += internal::math::pow(static_cast<float>(nperdim), Ndim - dim - 1) *
-                      getBin(coords[dim], dim);
+        global_bin +=
+            math::pow(static_cast<float>(nperdim), Ndim - dim - 1) * getBin(coords[dim], dim);
       }
       global_bin += getBin(coords[Ndim - 1], Ndim - 1);
       return global_bin;
@@ -63,7 +63,7 @@ namespace clue::internal {
       int32_t globalBin = 0;
       for (auto dim = 0u; dim != Ndim; ++dim) {
         auto bin_i = wrapping[dim] ? (Bins[dim] % nperdim) : Bins[dim];
-        globalBin += internal::math::pow(static_cast<float>(nperdim), Ndim - dim - 1) * bin_i;
+        globalBin += math::pow(static_cast<float>(nperdim), Ndim - dim - 1) * bin_i;
       }
       return globalBin;
     }
@@ -102,10 +102,9 @@ namespace clue::internal {
       std::array<float, Ndim> distance_vector;
       for (auto dim = 0u; dim != Ndim; ++dim) {
         if (wrapping[dim])
-          distance_vector[dim] =
-              internal::math::fabs(normalizeCoordinate(coord_i[dim] - coord_j[dim], dim));
+          distance_vector[dim] = math::fabs(normalizeCoordinate(coord_i[dim] - coord_j[dim], dim));
         else
-          distance_vector[dim] = internal::math::fabs(coord_i[dim] - coord_j[dim]);
+          distance_vector[dim] = math::fabs(coord_i[dim] - coord_j[dim]);
       }
       return distance_vector;
     }

--- a/include/CLUEstering/internal/math/exp/exp.hpp
+++ b/include/CLUEstering/internal/math/exp/exp.hpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #endif
 
-namespace clue::internal::math {
+namespace clue::math {
 
   ALPAKA_FN_ACC inline constexpr float exp(float x) {
 #if defined(CUDA_DEVICE_FN)
@@ -51,4 +51,4 @@ namespace clue::internal::math {
     return exp(static_cast<double>(x));
   }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math

--- a/include/CLUEstering/internal/math/fabs/fabs.hpp
+++ b/include/CLUEstering/internal/math/fabs/fabs.hpp
@@ -6,7 +6,7 @@
 
 #include "CLUEstering/internal/math/defines.hpp"
 
-namespace clue::internal::math {
+namespace clue::math {
 
   ALPAKA_FN_ACC inline constexpr float fabs(float arg) {
 #if defined(CUDA_DEVICE_FN)
@@ -34,4 +34,4 @@ namespace clue::internal::math {
 #endif
   }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math

--- a/include/CLUEstering/internal/math/max/max.hpp
+++ b/include/CLUEstering/internal/math/max/max.hpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #endif
 
-namespace clue::internal::math {
+namespace clue::math {
 
   template <clue::concepts::Numeric T>
   ALPAKA_FN_ACC inline constexpr T max(const T& a, const T& b) {
@@ -46,4 +46,4 @@ namespace clue::internal::math {
 #endif
   }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math

--- a/include/CLUEstering/internal/math/min/min.hpp
+++ b/include/CLUEstering/internal/math/min/min.hpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #endif
 
-namespace clue::internal::math {
+namespace clue::math {
 
   template <clue::concepts::Numeric T>
   ALPAKA_FN_ACC inline constexpr T min(const T& a, const T& b) {
@@ -46,4 +46,4 @@ namespace clue::internal::math {
 #endif
   }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math

--- a/include/CLUEstering/internal/math/pow/pow.hpp
+++ b/include/CLUEstering/internal/math/pow/pow.hpp
@@ -9,7 +9,7 @@
 #include <cmath>
 #endif
 
-namespace clue::internal::math {
+namespace clue::math {
 
   ALPAKA_FN_ACC inline constexpr float pow(float base, float exp) {
 #if defined(CUDA_DEVICE_FN)
@@ -45,4 +45,4 @@ namespace clue::internal::math {
 
   ALPAKA_FN_ACC inline constexpr float powf(float base, float exp) { return pow(base, exp); }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math

--- a/include/CLUEstering/internal/math/sqrt/sqrt.hpp
+++ b/include/CLUEstering/internal/math/sqrt/sqrt.hpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #endif
 
-namespace clue::internal::math {
+namespace clue::math {
 
   ALPAKA_FN_ACC inline constexpr float sqrt(float x) {
 #if defined(CUDA_DEVICE_FN)
@@ -51,4 +51,4 @@ namespace clue::internal::math {
     return sqrt(static_cast<double>(x));
   }
 
-}  // namespace clue::internal::math
+}  // namespace clue::math


### PR DESCRIPTION
The `clue::internal::math` namespace was making the code too verbose, so the math functions are moved to the `clue::math` namespace.