### PR TITLE
Reorder arguments of `Tiles::initialize`

### DIFF
--- a/include/CLUEstering/core/detail/SetupTiles.hpp
+++ b/include/CLUEstering/core/detail/SetupTiles.hpp
@@ -34,7 +34,7 @@ namespace clue::detail {
     // check if tiles are large enough for current data
     if ((tiles->extents().values < static_cast<std::size_t>(points.size())) or
         (tiles->extents().keys < static_cast<std::size_t>(ntiles))) {
-      tiles->initialize(points.size(), ntiles, n_per_dim, queue);
+      tiles->initialize(queue, points.size(), ntiles, n_per_dim);
     } else {
       tiles->reset(points.size(), ntiles, n_per_dim);
     }
@@ -67,7 +67,7 @@ namespace clue::detail {
     // check if tiles are large enough for current data
     if ((tiles->extents().values < static_cast<std::size_t>(points.size())) or
         (tiles->extents().keys < static_cast<std::size_t>(ntiles))) {
-      tiles->initialize(points.size(), ntiles, n_per_dim, queue);
+      tiles->initialize(queue, points.size(), ntiles, n_per_dim);
     } else {
       tiles->reset(points.size(), ntiles, n_per_dim);
     }

--- a/include/CLUEstering/data_structures/internal/Tiles.hpp
+++ b/include/CLUEstering/data_structures/internal/Tiles.hpp
@@ -43,7 +43,7 @@ namespace clue::internal {
     TilesView<Ndim>& view() { return m_view; }
 
     template <clue::concepts::queue TQueue>
-    ALPAKA_FN_HOST void initialize(int32_t npoints, int32_t ntiles, int32_t nperdim, TQueue& queue) {
+    ALPAKA_FN_HOST void initialize(TQueue& queue, int32_t npoints, int32_t ntiles, int32_t nperdim) {
       m_assoc.initialize(npoints, ntiles, queue);
       m_ntiles = ntiles;
       m_nperdim = nperdim;


### PR DESCRIPTION
This is needed for batching to that the `batch_size` can be added as last defaulted argument.