### PR TITLE
Remove unused variable `reserve`

### DIFF
--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -39,7 +39,6 @@ namespace clue {
     using TilesDevice = clue::internal::Tiles<Ndim, clue::Device>;
     using FollowersDevice = clue::Followers<clue::Device>;
     using Acc = internal::Acc;
-    inline static constexpr auto reserve = detail::reserve;
 
     DistanceParameter<Ndim> m_dc;
     DistanceParameter<Ndim> m_seed_dc;

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -19,8 +19,6 @@
 
 namespace clue::detail {
 
-  constexpr int32_t reserve = 1000000;
-
   template <typename TAcc, std::size_t Ndim, std::size_t N_, concepts::convolutional_kernel KernelType>
   ALPAKA_FN_ACC void for_recursion(const TAcc& acc,
                                    VecArray<int32_t, Ndim>& base_vec,


### PR DESCRIPTION
After PR #311, the `reserve` constexpr variable is not needed anymore.