### PR TITLE
Add contributor Markus Holzer to .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -32,6 +32,11 @@
 	  "affiliation": "INFN-CNAF",
 	  "orcid": "0000-0002-3129-2814"
 	},
+ 	{
+	  "name": "Holzer, Markus",
+	  "affiliation": "CERN",
+	  "orcid": "0000-0001-5499-5857"
+	},
   ],
   "access_right": "open",
   "keywords": [


### PR DESCRIPTION
Added a new contributor with details for Markus Holzer.