### PR TITLE
Fix name of `Euclidean` distance metric

### DIFF
--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -23,5 +23,5 @@ void run(float dc,
   clue::PointsHost<Ndim> h_points(queue, n_points, std::get<0>(pData), std::get<1>(pData));
   clue::PointsDevice<Ndim> d_points(queue, n_points);
 
-  algo.make_clusters(queue, h_points, d_points, clue::EuclidianMetric<Ndim>{}, kernel, block_size);
+  algo.make_clusters(queue, h_points, d_points, clue::EuclideanMetric<Ndim>{}, kernel, block_size);
 }

--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -58,7 +58,7 @@ namespace clue {
     }
 
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters_impl(PointsHost& h_points,
                             PointsDevice& dev_points,
                             const DistanceMetric& metric,
@@ -66,7 +66,7 @@ namespace clue {
                             Queue& queue,
                             std::size_t block_size);
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters_impl(PointsDevice& dev_points,
                             const DistanceMetric& metric,
                             const Kernel& kernel,
@@ -115,10 +115,10 @@ namespace clue {
     /// @param kernel The convolutional kernel to use for computing the local densities, default is FlatKernel with height 0.5
     /// @param block_size The size of the blocks to use for clustering, default is 256
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters(Queue& queue,
                        PointsHost& h_points,
-                       const DistanceMetric& metric = clue::EuclidianMetric<Ndim>{},
+                       const DistanceMetric& metric = clue::EuclideanMetric<Ndim>{},
                        const Kernel& kernel = FlatKernel{.5f},
                        std::size_t block_size = 256);
     /// @brief Construct the clusters from host points
@@ -128,9 +128,9 @@ namespace clue {
     /// @param block_size The size of the blocks to use for clustering, default is 256
     /// @note This method creates a temporary queue for the operations on the device
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters(PointsHost& h_points,
-                       const DistanceMetric& metric = clue::EuclidianMetric<Ndim>{},
+                       const DistanceMetric& metric = clue::EuclideanMetric<Ndim>{},
                        const Kernel& kernel = FlatKernel{.5f},
                        std::size_t block_size = 256);
     /// @brief Construct the clusters from host and device points
@@ -141,11 +141,11 @@ namespace clue {
     /// @param kernel The convolutional kernel to use for computing the local densities, default is FlatKernel with height 0.5
     /// @param block_size The size of the blocks to use for clustering, default is 256
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters(Queue& queue,
                        PointsHost& h_points,
                        PointsDevice& dev_points,
-                       const DistanceMetric& metric = clue::EuclidianMetric<Ndim>{},
+                       const DistanceMetric& metric = clue::EuclideanMetric<Ndim>{},
                        const Kernel& kernel = FlatKernel{.5f},
                        std::size_t block_size = 256);
     /// @brief Construct the clusters from device points
@@ -155,10 +155,10 @@ namespace clue {
     /// @param kernel The convolutional kernel to use for computing the local densities, default is FlatKernel with height 0.5
     /// @param block_size The size of the blocks to use for clustering, default is 256
     template <concepts::convolutional_kernel Kernel = FlatKernel,
-              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclidianMetric<Ndim>>
+              concepts::distance_metric<Ndim> DistanceMetric = clue::EuclideanMetric<Ndim>>
     void make_clusters(Queue& queue,
                        PointsDevice& dev_points,
-                       const DistanceMetric& metric = clue::EuclidianMetric<Ndim>{},
+                       const DistanceMetric& metric = clue::EuclideanMetric<Ndim>{},
                        const Kernel& kernel = FlatKernel{.5f},
                        std::size_t block_size = 256);
 

--- a/include/CLUEstering/core/DistanceMetrics.hpp
+++ b/include/CLUEstering/core/DistanceMetrics.hpp
@@ -27,23 +27,23 @@ namespace clue {
   template <std::size_t Ndim>
   using Point = std::array<float, Ndim + 1>;
 
-  /// @brief Euclidian distance metric
-  //// This class implements the Euclidian distance metric in Ndim dimensions.
+  /// @brief Euclidean distance metric
+  //// This class implements the Euclidean distance metric in Ndim dimensions.
   ///
   /// @tparam Ndim Number of dimensions
   template <std::size_t Ndim>
-  class EuclidianMetric {
+  class EuclideanMetric {
   public:
     /// @brief Default constructor
     ///
-    /// @return EuclidianMetric object
-    ALPAKA_FN_HOST_ACC constexpr EuclidianMetric() = default;
+    /// @return EuclideanMetric object
+    ALPAKA_FN_HOST_ACC constexpr EuclideanMetric() = default;
 
-    /// @brief Compute the Euclidian distance between two points
+    /// @brief Compute the Euclidean distance between two points
     ///
     /// @param lhs First point
     /// @param rhs Second point
-    /// @return Euclidian distance between the two points
+    /// @return Euclidean distance between the two points
     ALPAKA_FN_HOST_ACC constexpr inline auto operator()(const Point<Ndim>& lhs,
                                                         const Point<Ndim>& rhs) const {
       const auto distance2 = meta::accumulate<Ndim>(
@@ -52,12 +52,12 @@ namespace clue {
     }
   };
 
-  /// @brief Weighted Euclidian distance metric
-  /// This class implements the Weighted Euclidian distance metric in Ndim dimensions.
+  /// @brief Weighted Euclidean distance metric
+  /// This class implements the Weighted Euclidean distance metric in Ndim dimensions.
   ///
   /// @tparam Ndim Number of dimensions
   template <std::size_t Ndim>
-  class WeightedEuclidianMetric {
+  class WeightedEuclideanMetric {
   private:
     std::array<float, Ndim> m_weights;
 
@@ -65,21 +65,21 @@ namespace clue {
     /// @brief Constructor euclidian metric with weights
     ///
     /// @param weights Weights for each dimension
-    /// @return WeightedEuclidianMetric object
-    ALPAKA_FN_HOST_ACC constexpr WeightedEuclidianMetric(const std::array<float, Ndim>& weights)
+    /// @return WeightedEuclideanMetric object
+    ALPAKA_FN_HOST_ACC constexpr WeightedEuclideanMetric(const std::array<float, Ndim>& weights)
         : m_weights{weights} {}
     /// @brief Move constructor euclidian metric with weights
     ///
     /// @param weights Weights for each dimension
-    /// @return WeightedEuclidianMetric object
-    ALPAKA_FN_HOST_ACC constexpr WeightedEuclidianMetric(std::array<float, Ndim>&& weights)
+    /// @return WeightedEuclideanMetric object
+    ALPAKA_FN_HOST_ACC constexpr WeightedEuclideanMetric(std::array<float, Ndim>&& weights)
         : m_weights{std::move(weights)} {}
 
-    /// @brief Compute the Weighted Euclidian distance between two points
+    /// @brief Compute the Weighted Euclidean distance between two points
     ///
     /// @param lhs First point
     /// @param rhs Second point
-    /// @return Weighted Euclidian distance between the two points
+    /// @return Weighted Euclidean distance between the two points
     ALPAKA_FN_HOST_ACC constexpr inline auto operator()(const Point<Ndim>& lhs,
                                                         const Point<Ndim>& rhs) const {
       const auto distance2 = meta::accumulate<Ndim>([&]<std::size_t Dim>() {
@@ -170,13 +170,13 @@ namespace clue {
 
   namespace metrics {
 
-    /// @brief Alias for Euclidian distance metric
+    /// @brief Alias for Euclidean distance metric
     template <std::size_t Ndim>
-    using Euclidian = clue::EuclidianMetric<Ndim>;
+    using Euclidean = clue::EuclideanMetric<Ndim>;
 
-    /// @brief Alias for Weighted Euclidian distance metric
+    /// @brief Alias for Weighted Euclidean distance metric
     template <std::size_t Ndim>
-    using WeightedEuclidian = clue::WeightedEuclidianMetric<Ndim>;
+    using WeightedEuclidean = clue::WeightedEuclideanMetric<Ndim>;
 
     /// @brief Alias for Manhattan distance metric
     template <std::size_t Ndim>


### PR DESCRIPTION
The Euclidean metric was erroneously called "Euclidian".