### PR TITLE
Set absolute path for test files in CMakeLists.txt

### DIFF
--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -10,8 +10,10 @@ foreach(source ${sources})
                                                ${doctest_SOURCE_DIR}/doctest)
   target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic fmt::fmt)
   target_compile_definitions(
-    ${target} PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-                      CLUE_ENABLE_CACHING_ALLOCATOR)
+    ${target}
+    PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+            CLUE_ENABLE_CACHING_ALLOCATOR
+            TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
   set_target_properties(
     ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/serial
                          OUTPUT_NAME ${test_name})
@@ -35,8 +37,10 @@ if(TBB_FOUND AND NOT COVERAGE)
     target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic
                                             TBB::tbb fmt::fmt)
     target_compile_definitions(
-      ${target} PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-                        CLUE_ENABLE_CACHING_ALLOCATOR)
+      ${target}
+      PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+              CLUE_ENABLE_CACHING_ALLOCATOR
+              TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
     set_target_properties(
       ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tbb
                            OUTPUT_NAME ${test_name})
@@ -55,8 +59,10 @@ if(OpenMP_CXX_FOUND AND NOT COVERAGE)
     target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic
                                             OpenMP::OpenMP_CXX fmt::fmt)
     target_compile_definitions(
-      ${target} PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-                        CLUE_ENABLE_CACHING_ALLOCATOR)
+      ${target}
+      PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+              CLUE_ENABLE_CACHING_ALLOCATOR
+              TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
     set_target_properties(
       ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/openmp
                            OUTPUT_NAME ${test_name})

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -21,8 +21,9 @@ foreach(source ${sources})
   target_include_directories(${target} PRIVATE ${CMAKE_SOURCE_DIR}/../include
                                                ${doctest_SOURCE_DIR}/doctest)
   target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic fmt::fmt)
-  target_compile_definitions(${target} PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED
-                                               CLUE_ENABLE_CACHING_ALLOCATOR)
+  target_compile_definitions(
+    ${target} PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED CLUE_ENABLE_CACHING_ALLOCATOR
+                      TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
   target_compile_options(${target} PRIVATE --expt-relaxed-constexpr)
   set_target_properties(${target} PROPERTIES CUDA_SEPARABLE_COMPILATION ON
                                              CUDA_ARCHITECTURES "75;80;90")

--- a/tests/hip/CMakeLists.txt
+++ b/tests/hip/CMakeLists.txt
@@ -16,8 +16,9 @@ foreach(source ${sources})
     ${target} PRIVATE ${CMAKE_SOURCE_DIR}/../include
                       ${doctest_SOURCE_DIR}/doctest ${HIP_INCLUDE_DIR})
   target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic fmt::fmt)
-  target_compile_definitions(${target} PRIVATE ALPAKA_ACC_GPU_HIP_ENABLED
-                                               CLUE_ENABLE_CACHING_ALLOCATOR)
+  target_compile_definitions(
+    ${target} PRIVATE ALPAKA_ACC_GPU_HIP_ENABLED CLUE_ENABLE_CACHING_ALLOCATOR
+                      TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
   set_target_properties(
     ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/hip
                          OUTPUT_NAME ${test_name})

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -13,6 +13,8 @@ foreach(source ${sources})
   target_include_directories(${target} PRIVATE ${oneDPL_DIR})
   target_compile_options(${target} PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                            -DALPAKA_SYCL_ONEAPI_CPU -fsycl)
+  target_compile_definitions(
+    ${target} PRIVATE TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
   target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic fmt::fmt
                                           -fsycl)
   set_target_properties(
@@ -31,6 +33,8 @@ foreach(source ${sources})
   target_include_directories(${target} PRIVATE ${oneDPL_DIR})
   target_compile_options(${target} PRIVATE -DALPAKA_ACC_SYCL_ENABLED
                                            -DALPAKA_SYCL_ONEAPI_GPU -fsycl)
+  target_compile_definitions(
+    ${target} PRIVATE TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../data")
   target_link_libraries(${target} PRIVATE alpaka::alpaka Boost::atomic fmt::fmt
                                           -fsycl)
   set_target_properties(

--- a/tests/test_cluster_centroid.cpp
+++ b/tests/test_cluster_centroid.cpp
@@ -16,7 +16,8 @@ TEST_CASE("Test computation of cluster centroid") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/sissa_1000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/data_32768.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -38,7 +39,8 @@ TEST_CASE("Test computation of all cluster centroids") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/sissa_1000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/data_32768.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 

--- a/tests/test_clusterer.cpp
+++ b/tests/test_clusterer.cpp
@@ -14,14 +14,14 @@ TEST_CASE("Test make_cluster interfaces") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/data_32768.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/data_32768.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
   const float dc{1.3f}, rhoc{10.f}, outlier{1.3f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 
-  auto truth = clue::read_output<2>(queue, "../../../data/truth_files/data_32768_truth.csv");
   SUBCASE("Run clustering without passing device points") {
     algo.make_clusters(queue, h_points);
 

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -21,8 +21,9 @@ TEST_CASE("Test clustering on benchmarking datasets") {
     const auto device = clue::get_device(0u);
     clue::Queue queue(device);
 
-    clue::PointsHost<2> h_points =
-        clue::read_csv<2>(queue, fmt::format("../../../data/data_{}.csv", std::pow(2, i)));
+    const auto test_file_path =
+        std::string(TEST_DATA_DIR) + fmt::format("/data_{}.csv", std::pow(2, i));
+    clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
     const auto n_points = h_points.size();
     clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -39,7 +40,8 @@ TEST_CASE("Test clustering on aniso dataset") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/aniso_1000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/aniso_1000.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -56,7 +58,8 @@ TEST_CASE("Test clustering on sissa 1000 dataset") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/sissa_1000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/sissa_1000.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -72,7 +75,8 @@ TEST_CASE("Test clustering on sissa 4000 dataset") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/sissa_4000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/sissa_4000.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -88,7 +92,8 @@ TEST_CASE("Test clustering on toy detector 1000 dataset") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/toyDetector_1000.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/toyDetector_1000.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -104,7 +109,8 @@ TEST_CASE("Test clustering on blob dataset") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<3> h_points = clue::read_csv<3>(queue, "../../../data/blob.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/blob.csv";
+  clue::PointsHost<3> h_points = clue::read_csv<3>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<3> d_points(queue, n_points);
 
@@ -120,7 +126,8 @@ TEST_CASE("Test clustering on data with periodic coordinates") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> points = clue::read_csv<2>(queue, "../../../data/opposite_angles.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/opposite_angles.csv";
+  clue::PointsHost<2> points = clue::read_csv<2>(queue, test_file_path);
   const float dc{.2f}, rhoc{5.f}, outlier{.2f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
 

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -64,7 +64,8 @@ TEST_CASE("Test get_clusters host function") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/data_32768.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/data_32768.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 
@@ -78,7 +79,8 @@ TEST_CASE("Test get_clusters device function") {
   const auto device = clue::get_device(0u);
   clue::Queue queue(device);
 
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../../data/data_32768.csv");
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/data_32768.csv";
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, test_file_path);
   const auto n_points = h_points.size();
   clue::PointsDevice<2> d_points(queue, n_points);
 

--- a/tests/test_validation_scores.cpp
+++ b/tests/test_validation_scores.cpp
@@ -6,7 +6,9 @@
 
 TEST_CASE("Test validation scores on toy detector dataset") {
   auto queue = clue::get_queue(0u);
-  clue::PointsHost<2> points = clue::read_csv<2>(queue, "../../../data/toyDetector_1000.csv");
+
+  const auto test_file_path = std::string(TEST_DATA_DIR) + "/toyDetector_1000.csv";
+  clue::PointsHost<2> points = clue::read_csv<2>(queue, test_file_path);
   clue::Clusterer<2> clusterer(queue, 4.f, 2.5f, 4.f);
   clusterer.make_clusters(queue, points);
 


### PR DESCRIPTION
This PR sets the absolute path to the `data` folder for the tests, making the execution less dependent on where it's executed from.