### PR TITLE
Add native CUDA and HIP examples

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install -y libboost-dev libtbb-dev libomp-dev
-        wget https://github.com/alpaka-group/alpaka/archive/refs/tags/2.0.0.tar.gz 
-        tar -xvf 2.0.0.tar.gz && cd alpaka-2.0.0
+        wget https://github.com/alpaka-group/alpaka/archive/refs/tags/2.1.0.tar.gz 
+        tar -xvf 2.1.0.tar.gz && cd alpaka-2.1.0
         cmake -B build && sudo cmake --install build
 
     - name: Install CLUEstering
@@ -30,7 +30,7 @@ jobs:
         cmake -B build && sudo cmake --install build
 
     - name: Compile and run examples
-      working-directory: ${{ github.workspace }}/examples
+      working-directory: ${{ github.workspace }}/examples/basic
       run: |
         cmake -B build/serial -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED=ON -DCMAKE_BUILD_TYPE=Release
         cmake -B build/tbb -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED=ON -DCMAKE_BUILD_TYPE=Release

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(CLUEsteringExample)
+project(BasicCLUEsteringExample)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)

--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -6,7 +6,7 @@ int main() {
   auto queue = clue::get_queue(0u);
 
   // Allocate the points on the host and device.
-  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../data/sissa_1000.csv");
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../data/sissa_1000.csv");
   clue::PointsDevice<2> d_points(queue, h_points.size());
 
   // Define the parameters for the clustering and construct the clusterer.

--- a/examples/cuda_native/CMakeLists.txt
+++ b/examples/cuda_native/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(NativeCUDACLUEsteringExample LANGUAGES CXX CUDA)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(CLUEstering REQUIRED)
+find_package(alpaka REQUIRED)
+if(NOT CLUEstering_FOUND)
+  message(
+    FATAL_ERROR
+      "CLUEstering not found. This example requires it to be installed. Please install following the instructions in the README."
+  )
+endif()
+
+include(CheckLanguage)
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+  add_executable(native_cuda.out main.cu)
+  target_link_libraries(native_cuda.out PRIVATE CLUEstering::CLUEstering
+                                                alpaka::alpaka)
+  target_compile_definitions(native_cuda.out
+                             PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED)
+  target_compile_options(native_cuda.out PRIVATE --expt-relaxed-constexpr)
+  set_target_properties(
+    native_cuda.out PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_ARCHITECTURES
+                                                             "75;80;90")
+else()
+  message(FATAL_ERROR "CUDA not found. Please install it.")
+endif()

--- a/examples/cuda_native/main.cu
+++ b/examples/cuda_native/main.cu
@@ -1,0 +1,32 @@
+
+#include <CLUEstering/CLUEstering.hpp>
+#include <cuda_runtime.h>
+#include <vector>
+
+template <typename TQueue>
+void compute_clusters(TQueue& queue, std::vector<int>& cluster_indexes) {
+  // Allocate the points on the host and device.
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../data/sissa_1000.csv");
+  clue::PointsDevice<2> d_points(queue, h_points.size());
+
+  // Define the parameters for the clustering and construct the clusterer.
+  const float dc = 20.f, rhoc = 10.f, outlier = 20.f;
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
+
+  // Launch the clustering
+  // The results will be stored in the `clue::PointsHost` object
+  algo.make_clusters(queue, h_points, d_points);
+
+  std::ranges::copy(h_points.clusterIndexes(), std::back_inserter(cluster_indexes));
+}
+
+int main() {
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  clue::Queue queue(stream);
+
+  std::vector<int> cluster_indexes;
+  compute_clusters(queue, cluster_indexes);
+
+  cudaStreamDestroy(stream);
+}

--- a/examples/hip_native/CMakeLists.txt
+++ b/examples/hip_native/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(NativeHIPCLUEsteringExample LANGUAGES CXX HIP)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(CLUEstering REQUIRED)
+find_package(alpaka REQUIRED)
+if(NOT CLUEstering_FOUND)
+  message(
+    FATAL_ERROR
+      "CLUEstering not found. This example requires it to be installed. Please install following the instructions in the README."
+  )
+endif()
+
+include(CheckLanguage)
+check_language(HIP)
+if(CMAKE_HIP_COMPILER)
+  add_executable(native_hip.out main.cpp)
+  target_link_libraries(native_hip.out PRIVATE CLUEstering::CLUEstering
+                                               alpaka::alpaka)
+  target_compile_definitions(native_hip.out PRIVATE ALPAKA_ACC_GPU_HIP_ENABLED)
+else()
+  message(FATAL_ERROR "CUDA not found. Please install it.")
+endif()

--- a/examples/hip_native/main.cpp
+++ b/examples/hip_native/main.cpp
@@ -1,0 +1,32 @@
+
+#include <CLUEstering/CLUEstering.hpp>
+#include <hip_runtime.h>
+#include <vector>
+
+template <typename TQueue>
+void compute_clusters(TQueue& queue, std::vector<int>& cluster_indexes) {
+  // Allocate the points on the host and device.
+  clue::PointsHost<2> h_points = clue::read_csv<2>(queue, "../../data/sissa_1000.csv");
+  clue::PointsDevice<2> d_points(queue, h_points.size());
+
+  // Define the parameters for the clustering and construct the clusterer.
+  const float dc = 20.f, rhoc = 10.f, outlier = 20.f;
+  clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
+
+  // Launch the clustering
+  // The results will be stored in the `clue::PointsHost` object
+  algo.make_clusters(queue, h_points, d_points);
+
+  std::ranges::copy(h_points.clusterIndexes(), std::back_inserter(cluster_indexes));
+}
+
+int main() {
+  hipStream_t stream;
+  hipStreamCreate(&stream);
+  clue::Queue queue(stream);
+
+  std::vector<int> cluster_indexes;
+  compute_clusters(queue, cluster_indexes);
+
+  hipStreamDestroy(stream);
+}


### PR DESCRIPTION
This PR adds examples where CLUEstering is used inside native CUDA and HIP code.
The use of the library remains the same, and since alpaka `2.1.0`, streams can be used to construct an alpaka queue.