### PR TITLE
Compile GPU tests only if GPU found

### DIFF
--- a/benchmark/dataset_size/CMakeLists.txt
+++ b/benchmark/dataset_size/CMakeLists.txt
@@ -36,13 +36,38 @@ endif()
 add_subdirectory(cpu)
 
 include(CheckLanguage)
+
+execute_process(
+  COMMAND nvidia-smi --query-gpu=name --format=csv,noheader
+  OUTPUT_VARIABLE GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT GPU_LIST STREQUAL "")
+  set(NVIDIA_GPU_PRESENT TRUE)
+else()
+  set(NVIDIA_GPU_PRESENT FALSE)
+endif()
+
 check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
+if(CMAKE_CUDA_COMPILER AND NVIDIA_GPU_PRESENT)
   add_subdirectory(cuda)
 endif()
 
+execute_process(
+  COMMAND rocm-smi --showproductname
+  OUTPUT_VARIABLE AMD_GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT AMD_GPU_LIST STREQUAL "")
+  set(AMD_GPU_PRESENT TRUE)
+else()
+  set(AMD_GPU_PRESENT FALSE)
+endif()
+
 check_language(HIP)
-if(CMAKE_HIP_COMPILER)
+if(CMAKE_HIP_COMPILER AND AMD_GPU_PRESENT)
   add_subdirectory(hip)
 endif()
 

--- a/benchmark/microbenchmarking/associator/CMakeLists.txt
+++ b/benchmark/microbenchmarking/associator/CMakeLists.txt
@@ -34,13 +34,38 @@ endif()
 add_subdirectory(cpu)
 
 include(CheckLanguage)
+
+execute_process(
+  COMMAND nvidia-smi --query-gpu=name --format=csv,noheader
+  OUTPUT_VARIABLE GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT GPU_LIST STREQUAL "")
+  set(NVIDIA_GPU_PRESENT TRUE)
+else()
+  set(NVIDIA_GPU_PRESENT FALSE)
+endif()
+
 check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
+if(CMAKE_CUDA_COMPILER AND NVIDIA_GPU_PRESENT)
   add_subdirectory(cuda)
 endif()
 
+execute_process(
+  COMMAND rocm-smi --showproductname
+  OUTPUT_VARIABLE AMD_GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT AMD_GPU_LIST STREQUAL "")
+  set(AMD_GPU_PRESENT TRUE)
+else()
+  set(AMD_GPU_PRESENT FALSE)
+endif()
+
 check_language(HIP)
-if(CMAKE_HIP_COMPILER)
+if(CMAKE_HIP_COMPILER AND AMD_GPU_PRESENT)
   add_subdirectory(hip)
 endif()
 

--- a/benchmark/profiling/CMakeLists.txt
+++ b/benchmark/profiling/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -34,13 +35,38 @@ endif()
 add_subdirectory(cpu)
 
 include(CheckLanguage)
+
+execute_process(
+  COMMAND nvidia-smi --query-gpu=name --format=csv,noheader
+  OUTPUT_VARIABLE GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT GPU_LIST STREQUAL "")
+  set(NVIDIA_GPU_PRESENT TRUE)
+else()
+  set(NVIDIA_GPU_PRESENT FALSE)
+endif()
+
 check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
+if(CMAKE_CUDA_COMPILER AND NVIDIA_GPU_PRESENT)
   add_subdirectory(cuda)
 endif()
 
+execute_process(
+  COMMAND rocm-smi --showproductname
+  OUTPUT_VARIABLE AMD_GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT AMD_GPU_LIST STREQUAL "")
+  set(AMD_GPU_PRESENT TRUE)
+else()
+  set(AMD_GPU_PRESENT FALSE)
+endif()
+
 check_language(HIP)
-if(CMAKE_HIP_COMPILER)
+if(CMAKE_HIP_COMPILER AND AMD_GPU_PRESENT)
   add_subdirectory(hip)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,13 +57,38 @@ enable_testing()
 add_subdirectory(cpu)
 
 include(CheckLanguage)
+
+execute_process(
+  COMMAND nvidia-smi --query-gpu=name --format=csv,noheader
+  OUTPUT_VARIABLE GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT GPU_LIST STREQUAL "")
+  set(NVIDIA_GPU_PRESENT TRUE)
+else()
+  set(NVIDIA_GPU_PRESENT FALSE)
+endif()
+
 check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
+if(CMAKE_CUDA_COMPILER AND NVIDIA_GPU_PRESENT)
   add_subdirectory(cuda)
 endif()
 
+execute_process(
+  COMMAND rocm-smi --showproductname
+  OUTPUT_VARIABLE AMD_GPU_LIST
+  ERROR_QUIET
+  RESULT_VARIABLE SMI_STATUS)
+
+if(SMI_STATUS EQUAL 0 AND NOT AMD_GPU_LIST STREQUAL "")
+  set(AMD_GPU_PRESENT TRUE)
+else()
+  set(AMD_GPU_PRESENT FALSE)
+endif()
+
 check_language(HIP)
-if(CMAKE_HIP_COMPILER)
+if(CMAKE_HIP_COMPILER AND AMD_GPU_PRESENT)
   add_subdirectory(hip)
 endif()
 


### PR DESCRIPTION
This PR only compiles the GPU tests and benchmarks if a GPU of the corresponding backend is actually found on the machine.
This should also fix the failing GPU workflows in PR #360.