### PR TITLE
Return `std::span` from points view accessors

### DIFF
--- a/include/CLUEstering/core/detail/BatchedClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/BatchedClusteringKernels.hpp
@@ -74,7 +74,7 @@ namespace clue::detail {
                                             event);
 
             assert(rho_i >= TData{0});
-            dev_points.rho[global_idx] = rho_i;
+            dev_points.rho()[global_idx] = rho_i;
           }
         }
       }
@@ -103,7 +103,7 @@ namespace clue::detail {
             auto delta_i = std::numeric_limits<TData>::max();
             int nh_i = -1;
             auto coords_i = dev_points[global_idx];
-            auto rho_i = dev_points.rho[global_idx];
+            auto rho_i = dev_points.rho()[global_idx];
 
             clue::SearchBoxExtremes<Ndim, TData> searchbox_extremes;
             for (auto dim = 0u; dim != Ndim; ++dim) {
@@ -130,7 +130,7 @@ namespace clue::detail {
                                                            event);
 
             assert(nh_i == -1 || delta_i <= dm);
-            dev_points.nearest_higher[global_idx] = nh_i;
+            dev_points.nearest_higher()[global_idx] = nh_i;
             if (nh_i == -1) {
               alpaka::atomicAdd(acc, seed_candidates, std::size_t{1});
             }
@@ -159,24 +159,24 @@ namespace clue::detail {
         for (const auto local_idx : alpaka::uniformElementsAlong<1u>(acc, max_event_size)) {
           const auto global_idx = event_offsets[event] + local_idx;
           if (global_idx < event_offsets[event + 1]) {
-            dev_points.cluster_index[global_idx] = -1;
-            auto nh = dev_points.nearest_higher[global_idx];
+            dev_points.cluster_index()[global_idx] = -1;
+            auto nh = dev_points.nearest_higher()[global_idx];
 
             auto coords_i = dev_points[global_idx];
             auto coords_nh = dev_points[nh];
             auto distance = metric(coords_i, coords_nh);
             assert(distance >= TData{0});
 
-            auto rho_i = dev_points.rho[global_idx];
+            auto rho_i = dev_points.rho()[global_idx];
             bool is_seed = (distance > seed_dc) && (rho_i >= rhoc);
 
             if (is_seed) {
-              dev_points.is_seed[global_idx] = 1;
-              dev_points.nearest_higher[global_idx] = -1;
+              dev_points.is_seed()[global_idx] = 1;
+              dev_points.nearest_higher()[global_idx] = -1;
               const auto prev = seeds.push_back(acc, global_idx);
               event_associations[prev] = event;
             } else {
-              dev_points.is_seed[global_idx] = 0;
+              dev_points.is_seed()[global_idx] = 0;
             }
           }
         }

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -50,7 +50,7 @@ namespace clue::detail {
 
       for (auto binIter = 0u; binIter < binSize; ++binIter) {
         int32_t j = tiles[binId][binIter];
-        assert(j >= 0 && j < dev_points.n);
+        assert(j >= 0 && j < dev_points.size());
 
         auto coords_j = dev_points[j];
         auto distance = metric(coords_i, coords_j);
@@ -151,7 +151,7 @@ namespace clue::detail {
 
       for (auto binIter = 0; binIter < binSize; ++binIter) {
         const auto j = tiles[binId][binIter];
-        assert(j >= 0 && j < dev_points.n);
+        assert(j >= 0 && j < dev_points.size());
         auto rho_j = dev_points.rho()[j];
         bool found_higher = (rho_j > rho_i);
         found_higher = found_higher || ((rho_j == rho_i) && (rho_j > TData{0}) && (j > point_id));

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -58,7 +58,7 @@ namespace clue::detail {
 
         auto k = kernel(acc, distance, point_id, j);
         assert(k >= TData{0});
-        rho_i += static_cast<int>(distance <= dc) * k * dev_points.weight[j];
+        rho_i += static_cast<int>(distance <= dc) * k * dev_points.weights()[j];
       }
       return;
     } else {
@@ -122,7 +122,7 @@ namespace clue::detail {
                                         i);
 
         assert(rho_i >= TData{0});
-        dev_points.rho[i] = rho_i;
+        dev_points.rho()[i] = rho_i;
       }
     }
   };
@@ -152,7 +152,7 @@ namespace clue::detail {
       for (auto binIter = 0; binIter < binSize; ++binIter) {
         const auto j = tiles[binId][binIter];
         assert(j >= 0 && j < dev_points.n);
-        auto rho_j = dev_points.rho[j];
+        auto rho_j = dev_points.rho()[j];
         bool found_higher = (rho_j > rho_i);
         found_higher = found_higher || ((rho_j == rho_i) && (rho_j > TData{0}) && (j > point_id));
 
@@ -208,7 +208,7 @@ namespace clue::detail {
         auto delta_i = std::numeric_limits<TData>::max();
         int nh_i = -1;
         auto coords_i = dev_points[i];
-        auto rho_i = dev_points.rho[i];
+        auto rho_i = dev_points.rho()[i];
 
         clue::SearchBoxExtremes<Ndim, TData> searchbox_extremes;
         for (auto dim = 0u; dim != Ndim; ++dim) {
@@ -233,7 +233,7 @@ namespace clue::detail {
                                                        i);
 
         assert(nh_i == -1 || delta_i <= dm);
-        dev_points.nearest_higher[i] = nh_i;
+        dev_points.nearest_higher()[i] = nh_i;
         if (nh_i == -1) {
           alpaka::atomicAdd(acc, seed_candidates, std::size_t{1});
         }
@@ -255,23 +255,23 @@ namespace clue::detail {
                                   TData rhoc,
                                   int32_t n_points) const {
       for (auto i : alpaka::uniformElements(acc, n_points)) {
-        dev_points.cluster_index[i] = -1;
-        auto nh = dev_points.nearest_higher[i];
+        dev_points.cluster_index()[i] = -1;
+        auto nh = dev_points.nearest_higher()[i];
 
         auto coords_i = dev_points[i];
         auto coords_nh = dev_points[nh];
         auto distance = metric(coords_i, coords_nh);
         assert(distance >= TData{0});
 
-        auto rho_i = dev_points.rho[i];
+        auto rho_i = dev_points.rho()[i];
         bool is_seed = (distance > seed_dc) && (rho_i >= rhoc);
 
         if (is_seed) {
-          dev_points.is_seed[i] = 1;
-          dev_points.nearest_higher[i] = -1;
+          dev_points.is_seed()[i] = 1;
+          dev_points.nearest_higher()[i] = -1;
           seeds.push_back(acc, i);
         } else {
-          dev_points.is_seed[i] = 0;
+          dev_points.is_seed()[i] = 0;
         }
       }
     }
@@ -289,13 +289,13 @@ namespace clue::detail {
         int local_stack_size = 0;
 
         int idx_this_seed = seeds[idx_cls];
-        dev_points.cluster_index[idx_this_seed] = idx_cls;
+        dev_points.cluster_index()[idx_this_seed] = idx_cls;
         local_stack[local_stack_size] = idx_this_seed;
         ++local_stack_size;
         while (local_stack_size > 0) {
           assert(local_stack_size <= 256);
           int idx_end_of_local_stack = local_stack[local_stack_size - 1];
-          int temp_cluster_index = dev_points.cluster_index[idx_end_of_local_stack];
+          int temp_cluster_index = dev_points.cluster_index()[idx_end_of_local_stack];
           local_stack[local_stack_size - 1] = -1;
           --local_stack_size;
           const auto& followers_ies = followers[idx_end_of_local_stack];
@@ -303,7 +303,7 @@ namespace clue::detail {
           for (auto j = 0u; j != followers_size; ++j) {
             int follower = followers_ies[j];
             assert(follower >= 0);
-            dev_points.cluster_index[follower] = temp_cluster_index;
+            dev_points.cluster_index()[follower] = temp_cluster_index;
             assert(local_stack_size < 256);
             local_stack[local_stack_size] = follower;
             ++local_stack_size;

--- a/include/CLUEstering/data_structures/detail/DeviceViewPartition.hpp
+++ b/include/CLUEstering/data_structures/detail/DeviceViewPartition.hpp
@@ -26,19 +26,19 @@ namespace clue::soa::device {
     using value_type = std::remove_cv_t<TElement>;
 
     meta::apply<Ndim>([&]<std::size_t Dim>() {
-      view.coords[Dim] =
+      view.m_coords[Dim] =
           reinterpret_cast<value_type*>(buffer + Dim * n_points * sizeof(value_type));
     });
-    view.weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
-    view.cluster_index =
+    view.m_weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
+    view.m_cluster_index =
         reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(value_type));
-    view.is_seed =
+    view.m_is_seed =
         reinterpret_cast<int*>(buffer + n_points * ((Ndim + 1) * sizeof(value_type) + sizeof(int)));
-    view.rho = reinterpret_cast<value_type*>(
+    view.m_rho = reinterpret_cast<value_type*>(
         buffer + n_points * ((Ndim + 1) * sizeof(value_type) + 2 * sizeof(int)));
-    view.nearest_higher = reinterpret_cast<int*>(
+    view.m_nearest_higher = reinterpret_cast<int*>(
         buffer + n_points * ((Ndim + 2) * sizeof(value_type) + 2 * sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
@@ -48,17 +48,17 @@ namespace clue::soa::device {
     using value_type = std::remove_cv_t<TElement>;
 
     meta::apply<Ndim>([&]<std::size_t Dim>() {
-      view.coords[Dim] =
+      view.m_coords[Dim] =
           reinterpret_cast<value_type*>(buffer + Dim * n_points * sizeof(value_type));
     });
-    view.weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
-    view.cluster_index =
+    view.m_weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
+    view.m_cluster_index =
         reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(value_type));
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(int));
-    view.nearest_higher =
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(int));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
@@ -70,14 +70,14 @@ namespace clue::soa::device {
     using value_type = std::remove_cv_t<TElement>;
 
     meta::apply<Ndim>(
-        [&]<std::size_t Dim>() { view.coords[Dim] = coordinates.data() + Dim * n_points; });
-    view.weight = weights.data();
-    view.cluster_index = output.data();
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
-    view.nearest_higher =
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = coordinates.data() + Dim * n_points; });
+    view.m_weight = weights.data();
+    view.m_cluster_index = output.data();
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
@@ -87,14 +87,15 @@ namespace clue::soa::device {
                                std::span<int> output) {
     using value_type = std::remove_cv_t<TElement>;
 
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = input.data() + Dim * n_points; });
-    view.weight = input.data() + Ndim * n_points;
-    view.cluster_index = output.data();
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
-    view.nearest_higher =
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = input.data() + Dim * n_points; });
+    view.m_weight = input.data() + Ndim * n_points;
+    view.m_cluster_index = output.data();
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
 
   template <std::size_t Ndim, std::floating_point TElement>
@@ -106,14 +107,15 @@ namespace clue::soa::device {
                                int* output) {
     using value_type = std::remove_cv_t<TElement>;
 
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = coordinates + Dim * n_points; });
-    view.weight = weights;
-    view.cluster_index = output;
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
-    view.nearest_higher =
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = coordinates + Dim * n_points; });
+    view.m_weight = weights;
+    view.m_cluster_index = output;
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
@@ -123,14 +125,14 @@ namespace clue::soa::device {
                                int* output) {
     using value_type = std::remove_cv_t<TElement>;
 
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = input + Dim * n_points; });
-    view.weight = input + Ndim * n_points;
-    view.cluster_index = output;
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
-    view.nearest_higher =
+    meta::apply<Ndim>([&]<std::size_t Dim>() { view.m_coords[Dim] = input + Dim * n_points; });
+    view.m_weight = input + Ndim * n_points;
+    view.m_cluster_index = output;
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement, concepts::pointer... TBuffers>
     requires(sizeof...(TBuffers) == Ndim + 2 and Ndim > 1)
@@ -141,14 +143,15 @@ namespace clue::soa::device {
     using value_type = std::remove_cv_t<TElement>;
     auto buffers_tuple = std::make_tuple(buffers...);
 
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = std::get<Dim>(buffers_tuple); });
-    view.weight = std::get<Ndim>(buffers_tuple);
-    view.cluster_index = std::get<Ndim + 1>(buffers_tuple);
-    view.is_seed = reinterpret_cast<int*>(alloc_buffer);
-    view.rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
-    view.nearest_higher =
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = std::get<Dim>(buffers_tuple); });
+    view.m_weight = std::get<Ndim>(buffers_tuple);
+    view.m_cluster_index = std::get<Ndim + 1>(buffers_tuple);
+    view.m_is_seed = reinterpret_cast<int*>(alloc_buffer);
+    view.m_rho = reinterpret_cast<value_type*>(alloc_buffer + n_points * sizeof(value_type));
+    view.m_nearest_higher =
         reinterpret_cast<int*>(alloc_buffer + n_points * (sizeof(value_type) + sizeof(int)));
-    view.n = n_points;
+    view.m_n = n_points;
   }
 
 }  // namespace clue::soa::device

--- a/include/CLUEstering/data_structures/detail/HostViewPartition.hpp
+++ b/include/CLUEstering/data_structures/detail/HostViewPartition.hpp
@@ -27,13 +27,13 @@ namespace clue::soa::host {
     using value_type = std::remove_cv_t<TElement>;
 
     meta::apply<Ndim>([&]<std::size_t Dim>() {
-      view.coords[Dim] =
+      view.m_coords[Dim] =
           reinterpret_cast<value_type*>(buffer + Dim * n_points * sizeof(value_type));
     });
-    view.weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
-    view.cluster_index =
+    view.m_weight = reinterpret_cast<value_type*>(buffer + Ndim * n_points * sizeof(value_type));
+    view.m_cluster_index =
         reinterpret_cast<int*>(buffer + (Ndim + 1) * n_points * sizeof(value_type));
-    view.n = n_points;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
@@ -41,20 +41,21 @@ namespace clue::soa::host {
                                TElement* coordinates,
                                TElement* weights,
                                int* cluster_indices) {
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = coordinates + Dim * n_points; });
-    view.weight = weights;
-    view.cluster_index = cluster_indices;
-    view.n = n_points;
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = coordinates + Dim * n_points; });
+    view.m_weight = weights;
+    view.m_cluster_index = cluster_indices;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
                                int32_t n_points,
                                TElement* input,
                                int* output) {
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = input + Dim * n_points; });
-    view.weight = input + Ndim * n_points;
-    view.cluster_index = output;
-    view.n = n_points;
+    meta::apply<Ndim>([&]<std::size_t Dim>() { view.m_coords[Dim] = input + Dim * n_points; });
+    view.m_weight = input + Ndim * n_points;
+    view.m_cluster_index = output;
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement, concepts::pointer... TBuffers>
     requires(sizeof...(TBuffers) == Ndim + 2 and Ndim > 1)
@@ -63,10 +64,11 @@ namespace clue::soa::host {
                                TBuffers... buffers) {
     auto buffers_tuple = std::make_tuple(buffers...);
 
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = std::get<Dim>(buffers_tuple); });
-    view.weight = std::get<Ndim>(buffers_tuple);
-    view.cluster_index = std::get<Ndim + 1>(buffers_tuple);
-    view.n = n_points;
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = std::get<Dim>(buffers_tuple); });
+    view.m_weight = std::get<Ndim>(buffers_tuple);
+    view.m_cluster_index = std::get<Ndim + 1>(buffers_tuple);
+    view.m_n = n_points;
   }
 
   template <std::size_t Ndim, std::floating_point TElement>
@@ -76,20 +78,21 @@ namespace clue::soa::host {
                                std::span<TElement> weights,
                                std::span<int> cluster_indices) {
     meta::apply<Ndim>(
-        [&]<std::size_t Dim>() { view.coords[Dim] = coordinates.data() + Dim * n_points; });
-    view.weight = weights.data();
-    view.cluster_index = cluster_indices.data();
-    view.n = n_points;
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = coordinates.data() + Dim * n_points; });
+    view.m_weight = weights.data();
+    view.m_cluster_index = cluster_indices.data();
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement>
   inline void partitionSoAView(PointsView<Ndim, TElement>& view,
                                int32_t n_points,
                                std::span<TElement> input,
                                std::span<int> cluster_indices) {
-    meta::apply<Ndim>([&]<std::size_t Dim>() { view.coords[Dim] = input.data() + Dim * n_points; });
-    view.weight = input.data() + Ndim * n_points;
-    view.cluster_index = cluster_indices.data();
-    view.n = n_points;
+    meta::apply<Ndim>(
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = input.data() + Dim * n_points; });
+    view.m_weight = input.data() + Ndim * n_points;
+    view.m_cluster_index = cluster_indices.data();
+    view.m_n = n_points;
   }
   template <std::size_t Ndim, std::floating_point TElement, std::ranges::contiguous_range... TBuffers>
     requires(sizeof...(TBuffers) == Ndim + 2 and Ndim > 1)
@@ -99,10 +102,10 @@ namespace clue::soa::host {
     auto buffers_tuple = std::forward_as_tuple(std::forward<TBuffers>(buffers)...);
 
     meta::apply<Ndim>(
-        [&]<std::size_t Dim>() { view.coords[Dim] = std::get<Dim>(buffers_tuple).data(); });
-    view.weight = std::get<Ndim>(buffers_tuple).data();
-    view.cluster_index = std::get<Ndim + 1>(buffers_tuple).data();
-    view.n = n_points;
+        [&]<std::size_t Dim>() { view.m_coords[Dim] = std::get<Dim>(buffers_tuple).data(); });
+    view.m_weight = std::get<Ndim>(buffers_tuple).data();
+    view.m_cluster_index = std::get<Ndim + 1>(buffers_tuple).data();
+    view.m_n = n_points;
   }
 
 }  // namespace clue::soa::host

--- a/include/CLUEstering/data_structures/detail/PointsConversion.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsConversion.hpp
@@ -22,8 +22,8 @@ namespace clue {
                          const PointsDevice<Ndim, TDeviceInput, TDev>& d_points) {
     alpaka::memcpy(
         queue,
-        make_host_view(h_points.m_view.cluster_index, h_points.size()),
-        make_device_view(alpaka::getDev(queue), d_points.m_view.cluster_index, h_points.size()));
+        make_host_view(h_points.m_view.m_cluster_index, h_points.size()),
+        make_device_view(alpaka::getDev(queue), d_points.m_view.m_cluster_index, h_points.size()));
     h_points.mark_clustered();
   }
 
@@ -33,8 +33,8 @@ namespace clue {
 
     alpaka::memcpy(
         queue,
-        make_host_view(h_points.m_view.cluster_index, h_points.size()),
-        make_device_view(alpaka::getDev(queue), d_points.m_view.cluster_index, h_points.size()));
+        make_host_view(h_points.m_view.m_cluster_index, h_points.size()),
+        make_device_view(alpaka::getDev(queue), d_points.m_view.m_cluster_index, h_points.size()));
     h_points.mark_clustered();
 
     return h_points;
@@ -51,12 +51,13 @@ namespace clue {
     meta::apply<Ndim>([&]<std::size_t Dim>() -> void {
       alpaka::memcpy(
           queue,
-          make_device_view(alpaka::getDev(queue), d_points.m_view.coords[Dim], h_points.size()),
-          make_host_view(h_points.m_view.coords[Dim], h_points.size()));
+          make_device_view(alpaka::getDev(queue), d_points.m_view.m_coords[Dim], h_points.size()),
+          make_host_view(h_points.m_view.m_coords[Dim], h_points.size()));
     });
-    alpaka::memcpy(queue,
-                   make_device_view(alpaka::getDev(queue), d_points.m_view.weight, h_points.size()),
-                   make_host_view(h_points.m_view.weight, h_points.size()));
+    alpaka::memcpy(
+        queue,
+        make_device_view(alpaka::getDev(queue), d_points.m_view.m_weight, h_points.size()),
+        make_host_view(h_points.m_view.m_weight, h_points.size()));
   }
 
   template <concepts::queue TQueue, std::size_t Ndim, std::floating_point TInput, concepts::device TDev>

--- a/include/CLUEstering/data_structures/detail/PointsHost.hpp
+++ b/include/CLUEstering/data_structures/detail/PointsHost.hpp
@@ -9,6 +9,7 @@
 #include "CLUEstering/internal/meta/apply.hpp"
 
 #include <alpaka/alpaka.hpp>
+#include <array>
 #include <cassert>
 #include <concepts>
 #include <optional>
@@ -96,10 +97,10 @@ namespace clue {
       throw std::out_of_range("Index out of range in PointsHost::operator[]");
 
     std::array<TData, Ndim> coords;
-    for (size_t dim = 0; dim < Ndim; ++dim) {
-      coords[dim] = m_view.coords[0][dim * m_size + idx];
+    for (auto dim = 0u; dim < Ndim; ++dim) {
+      coords[dim] = m_view.coords()[0][dim * m_size + idx];
     }
-    return Point(coords, m_view.weight[idx], m_view.cluster_index[idx]);
+    return Point(coords, m_view.weights()[idx], m_view.cluster_index()[idx]);
   }
 
   template <std::size_t Ndim, std::floating_point TData>

--- a/include/CLUEstering/data_structures/internal/Followers.hpp
+++ b/include/CLUEstering/data_structures/internal/Followers.hpp
@@ -34,11 +34,7 @@ namespace clue {
               std::size_t Ndim,
               std::floating_point TData>
     ALPAKA_FN_HOST void fill(TQueue& queue, const PointsDevice<Ndim, TData, TDev>& d_points) {
-      m_assoc.template fill<TAcc>(
-          d_points.size(),
-          std::span<const std::int32_t>{d_points.view().nearest_higher,
-                                        static_cast<std::size_t>(d_points.size())},
-          queue);
+      m_assoc.template fill<TAcc>(d_points.size(), d_points.view().nearest_higher(), queue);
     }
 
     ALPAKA_FN_HOST inline constexpr int32_t extents() const { return m_assoc.extents().values; }

--- a/include/CLUEstering/data_structures/internal/Tiles.hpp
+++ b/include/CLUEstering/data_structures/internal/Tiles.hpp
@@ -92,7 +92,7 @@ namespace clue::internal {
       ALPAKA_FN_ACC int32_t operator()(int32_t index, std::size_t event = 0) const {
         value_type coords[Ndim];
         for (auto dim = 0u; dim < Ndim; ++dim) {
-          coords[dim] = pointsView.coords[dim][index];
+          coords[dim] = pointsView.coords()[dim][index];
         }
 
         auto bin = tilesView.getGlobalBin(coords, event);

--- a/include/CLUEstering/utils/detail/read_csv.hpp
+++ b/include/CLUEstering/utils/detail/read_csv.hpp
@@ -73,12 +73,12 @@ namespace clue {
 
       for (auto dim = 0u; dim < NDim; ++dim) {
         getline(buffer_stream, value, ',');
-        view.coords[dim][point_id] = std::stof(value);
+        view.m_coords[dim][point_id] = std::stof(value);
       }
       getline(buffer_stream, value, ',');
-      view.weight[point_id] = std::stof(value);
+      view.m_weight[point_id] = std::stof(value);
       getline(buffer_stream, value, ',');
-      view.cluster_index[point_id] = std::stoi(value);
+      view.m_cluster_index[point_id] = std::stoi(value);
 
       ++point_id;
     }

--- a/tests/test_device_points.cpp
+++ b/tests/test_device_points.cpp
@@ -22,9 +22,9 @@ struct KernelCompareDevicePoints {
     for (auto i : alpaka::uniformElements(acc, size)) {
       int comparison = 1;
       for (auto dim = 0u; dim < Ndim; ++dim) {
-        comparison = (view.coords[dim][i] == d_input[i + dim * size]);
+        comparison = (view.coords()[dim][i] == d_input[i + dim * size]);
       }
-      comparison = (view.weight[i] == d_input[i + Ndim * size]);
+      comparison = (view.weights()[i] == d_input[i + Ndim * size]);
 
       alpaka::atomicAnd(acc, result, comparison);
     }

--- a/tests/test_host_points.cpp
+++ b/tests/test_host_points.cpp
@@ -1,6 +1,7 @@
 
 #include "CLUEstering/CLUEstering.hpp"
 
+#include <algorithm>
 #include <numeric>
 #include <ranges>
 #include <span>
@@ -17,17 +18,17 @@ TEST_CASE("Test host points with internal allocation") {
   clue::PointsHost<2> h_points(queue, size);
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -37,22 +38,21 @@ TEST_CASE("Test host points with internal allocation") {
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -66,17 +66,17 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
   clue::PointsHost<2> h_points(queue, size, std::span(buffer.data(), buffer.size()));
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -86,22 +86,21 @@ TEST_CASE("Test host points with external allocation of whole buffer") {
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -117,17 +116,17 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
       queue, size, std::span(input.data(), input.size()), std::span(output.data(), output.size()));
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -137,22 +136,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as span
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -167,17 +165,17 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
   clue::PointsHost<2> h_points(queue, size, input, output);
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -187,22 +185,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as vect
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -217,17 +214,17 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
   clue::PointsHost<2> h_points(queue, size, input.data(), output.data());
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -237,22 +234,21 @@ TEST_CASE("Test host points with external allocation passing two buffers as poin
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -272,17 +268,17 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
                                std::span(cluster_ids_vector.data(), cluster_ids_vector.size()));
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -292,22 +288,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as spa
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -323,17 +318,17 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
   clue::PointsHost<2> h_points(queue, size, coords_vector, weights_vector, cluster_ids_vector);
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -343,22 +338,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as vec
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -375,17 +369,17 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
       queue, size, coords_vector.data(), weights_vector.data(), cluster_ids_vector.data());
   auto view = h_points.view();
 
-  CHECK(view.n == size);
+  CHECK(view.size() == size);
   SUBCASE("Set from host span") {
     auto coords = h_points.coords(0);
     auto weights = h_points.weights();
 
     std::iota(coords.begin(), coords.end(), 0.f);
-    std::fill(weights.begin(), weights.end(), 1.f);
+    std::ranges::fill(weights, 1.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(coords, std::span(view.coords[0], size)));
-    CHECK(std::ranges::equal(weights, std::span(view.weight, size)));
+    CHECK(std::ranges::equal(coords, view.coords()[0]));
+    CHECK(std::ranges::equal(weights, view.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
@@ -395,22 +389,21 @@ TEST_CASE("Test host points with external allocation passing four buffers as poi
   }
 
   SUBCASE("Set from view") {
-    auto coords = view.coords[0];
-    auto weights = view.weight;
+    auto coords = view.coords()[0];
+    auto weights = view.weights();
 
-    std::iota(coords, coords + 2 * size, 2000.f);
-    std::fill(weights, weights + size, 2.f);
+    std::iota(coords.data(), coords.data() + 2 * size, 2000.f);
+    std::ranges::fill(weights, 2.f);
 
     // compare with content of the view
-    CHECK(std::ranges::equal(std::span(coords, size), h_points.coords(0)));
-    CHECK(std::ranges::equal(std::span(weights, size), h_points.weights()));
+    CHECK(std::ranges::equal(coords, h_points.coords(0)));
+    CHECK(std::ranges::equal(weights, h_points.weights()));
 
     // check content
     auto to_float = [](int i) -> float { return static_cast<float>(i); };
     CHECK(std::ranges::equal(
-        std::span(coords, size),
-        std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
-    std::ranges::for_each(std::span(weights, size), [](auto x) { CHECK(x == 2.f); });
+        coords, std::views::iota(2000) | std::views::take(size) | std::views::transform(to_float)));
+    std::ranges::for_each(weights, [](auto x) { CHECK(x == 2.f); });
   }
 }
 
@@ -520,7 +513,7 @@ TEST_CASE("Test cluster properties accessors") {
 
   clue::PointsHost<2> h_points = clue::read_csv<2, float>(queue, "../../../data/data_32768.csv");
 
-  const float dc{1.3f}, rhoc{10.f}, outlier{1.3f};
+  const auto dc{1.3f}, rhoc{10.f}, outlier{1.3f};
   clue::Clusterer<2> algo(queue, dc, rhoc, outlier);
   algo.make_clusters(queue, h_points);
 


### PR DESCRIPTION
This PR makes the accessors for the points View return `std::span` instead of raw pointers.
Closes #435