### PR TITLE
Design bottom-to-top cluster assigning kernel

### DIFF
--- a/include/CLUEstering/core/Clusterer.hpp
+++ b/include/CLUEstering/core/Clusterer.hpp
@@ -7,7 +7,6 @@
 #include "CLUEstering/core/DistanceMetrics.hpp"
 #include "CLUEstering/core/ConvolutionalKernel.hpp"
 #include "CLUEstering/core/detail/ClusteringKernels.hpp"
-#include "CLUEstering/core/detail/SetupFollowers.hpp"
 #include "CLUEstering/core/detail/SetupTiles.hpp"
 #include "CLUEstering/core/detail/defines.hpp"
 #include "CLUEstering/data_structures/AssociationMap.hpp"
@@ -15,7 +14,6 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/PointsConversion.hpp"
 #include "CLUEstering/data_structures/internal/DeviceVector.hpp"
-#include "CLUEstering/data_structures/internal/Followers.hpp"
 #include "CLUEstering/data_structures/internal/SeedArray.hpp"
 #include "CLUEstering/data_structures/internal/Tiles.hpp"
 
@@ -51,7 +49,6 @@ namespace clue {
 
     std::optional<internal::Tiles<Ndim, value_type, clue::Device>> m_tiles;
     std::optional<internal::SeedArray<>> m_seeds;
-    std::optional<Followers<clue::Device>> m_followers;
     std::optional<internal::DeviceVector<>> m_event_associations;
 
     template <std::floating_point InputType>
@@ -59,7 +56,6 @@ namespace clue {
                const clue::PointsHost<Ndim, InputType>& h_points,
                clue::PointsDevice<Ndim, value_type>& dev_points) {
       detail::setup_tiles(queue, h_points, m_tiles, m_pointsPerTile, m_wrappedCoordinates);
-      detail::setup_followers(queue, m_followers, h_points.size());
       clue::copyToDevice(queue, dev_points, h_points);
     }
 
@@ -70,7 +66,6 @@ namespace clue {
                      std::size_t batch_size) {
       detail::setup_tiles(
           queue, h_points, m_tiles, m_pointsPerTile, m_wrappedCoordinates, batch_size);
-      detail::setup_followers(queue, m_followers, h_points.size());
       clue::copyToDevice(queue, dev_points, h_points);
     }
 
@@ -80,7 +75,6 @@ namespace clue {
                      std::size_t batch_size) {
       detail::setup_tiles(
           queue, dev_points, m_tiles, m_pointsPerTile, m_wrappedCoordinates, batch_size);
-      detail::setup_followers(queue, m_followers, dev_points.size());
     }
 
     template <

--- a/include/CLUEstering/core/detail/BatchedClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/BatchedClusteringKernels.hpp
@@ -7,7 +7,6 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/internal/PointsCommon.hpp"
 #include "CLUEstering/data_structures/internal/DeviceVector.hpp"
-#include "CLUEstering/data_structures/internal/Followers.hpp"
 #include "CLUEstering/data_structures/internal/SearchBox.hpp"
 #include "CLUEstering/data_structures/internal/SeedArray.hpp"
 #include "CLUEstering/data_structures/internal/TilesView.hpp"

--- a/include/CLUEstering/core/detail/Clusterer.hpp
+++ b/include/CLUEstering/core/detail/Clusterer.hpp
@@ -8,12 +8,10 @@
 #include "CLUEstering/core/detail/ClusteringKernels.hpp"
 #include "CLUEstering/core/detail/ComputeTiles.hpp"
 #include "CLUEstering/core/detail/defines.hpp"
-#include "CLUEstering/core/detail/SetupFollowers.hpp"
 #include "CLUEstering/core/detail/SetupSeeds.hpp"
 #include "CLUEstering/core/detail/SetupTiles.hpp"
 #include "CLUEstering/data_structures/PointsHost.hpp"
 #include "CLUEstering/data_structures/PointsDevice.hpp"
-#include "CLUEstering/data_structures/internal/Followers.hpp"
 #include "CLUEstering/data_structures/internal/SeedArray.hpp"
 #include "CLUEstering/data_structures/internal/Tiles.hpp"
 #include "CLUEstering/internal/nostd/ceil_div.hpp"
@@ -158,7 +156,6 @@ namespace clue {
       const Kernel& kernel,
       std::size_t block_size) {
     detail::setup_tiles(queue, dev_points, m_tiles, m_pointsPerTile, m_wrappedCoordinates);
-    detail::setup_followers(queue, m_followers, dev_points.size());
     make_clusters_impl(dev_points, metric, kernel, queue, block_size);
     alpaka::wait(queue);
   }
@@ -299,10 +296,8 @@ namespace clue {
                                             m_min_density,
                                             n_points);
 
-    m_followers->template fill<internal::Acc>(queue, dev_points);
-
     detail::assignPointsToClusters<internal::Acc>(
-        queue, block_size, m_seeds.value(), m_followers->view(), dev_points.view());
+        queue, block_size, m_seeds.value(), dev_points.view(), n_points);
 
     alpaka::wait(queue);
     internal::points_interface<std::remove_cvref_t<decltype(dev_points)>>::mark_clustered(
@@ -370,10 +365,8 @@ namespace clue {
                                                      m_event_associations->view(),
                                                      block_size);
 
-    m_followers->template fill<internal::Acc>(queue, dev_points);
-
     detail::assignPointsToClusters<internal::Acc>(
-        queue, block_size, m_seeds.value(), m_followers->view(), dev_points.view());
+        queue, block_size, m_seeds.value(), dev_points.view(), n_points);
 
     alpaka::wait(queue);
     internal::points_interface<std::remove_cvref_t<decltype(dev_points)>>::mark_clustered(

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -6,7 +6,6 @@
 #include "CLUEstering/data_structures/PointsDevice.hpp"
 #include "CLUEstering/data_structures/internal/PointsCommon.hpp"
 #include "CLUEstering/data_structures/internal/DeviceVector.hpp"
-#include "CLUEstering/data_structures/internal/Followers.hpp"
 #include "CLUEstering/data_structures/internal/SearchBox.hpp"
 #include "CLUEstering/data_structures/internal/SeedArray.hpp"
 #include "CLUEstering/data_structures/internal/TilesView.hpp"
@@ -286,41 +285,59 @@ namespace clue::detail {
     }
   };
 
-  struct KernelAssignClusters {
+  struct KernelAssignSeedIndices {
     template <typename TAcc, std::size_t Ndim, std::floating_point TData>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   clue::internal::SeedArrayView seeds,
-                                  clue::FollowersView followers,
                                   PointsView<Ndim, TData> dev_points) const {
-      const auto n_seeds = seeds.size();
-      for (auto idx_cls : alpaka::uniformElements(acc, n_seeds)) {
-        int local_stack[256] = {-1};
-        int local_stack_size = 0;
-
-        int idx_this_seed = seeds[idx_cls];
-        dev_points.cluster_index()[idx_this_seed] = idx_cls;
-        local_stack[local_stack_size] = idx_this_seed;
-        ++local_stack_size;
-        while (local_stack_size > 0) {
-          assert(local_stack_size <= 256);
-          int idx_end_of_local_stack = local_stack[local_stack_size - 1];
-          int temp_cluster_index = dev_points.cluster_index()[idx_end_of_local_stack];
-          local_stack[local_stack_size - 1] = -1;
-          --local_stack_size;
-          const auto& followers_ies = followers[idx_end_of_local_stack];
-          const auto followers_size = followers_ies.size();
-          for (auto j = 0u; j != followers_size; ++j) {
-            int follower = followers_ies[j];
-            assert(follower >= 0);
-            dev_points.cluster_index()[follower] = temp_cluster_index;
-            assert(local_stack_size < 256);
-            local_stack[local_stack_size] = follower;
-            ++local_stack_size;
-          }
-        }
+      for (auto cls_idx : alpaka::uniformElements(acc, seeds.size())) {
+        dev_points.cluster_index()[seeds[cls_idx]] = static_cast<int>(cls_idx);
       }
     }
   };
+
+  struct KernelAssignClusters {
+    template <typename TAcc, std::size_t Ndim, std::floating_point TData>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                  PointsView<Ndim, TData> dev_points,
+                                  int32_t n_points) const {
+      for (auto idx : alpaka::uniformElements(acc, n_points)) {
+        if (dev_points.is_seed()[idx] || dev_points.nearest_higher()[idx] == -1)
+          continue;
+
+        auto current = idx;
+        while (!dev_points.is_seed()[current] && dev_points.nearest_higher()[current] != -1)
+          current = dev_points.nearest_higher()[current];
+
+        dev_points.cluster_index()[idx] = dev_points.cluster_index()[current];
+      }
+    }
+  };
+
+  // struct OldKernelAssignClusters {
+  //   template <typename TAcc, std::size_t Ndim, std::floating_point TData>
+  //   ALPAKA_FN_ACC void operator()(const TAcc& acc,
+  //                                 clue::internal::SeedArrayView seeds,
+  //                                 clue::FollowersView followers,
+  //                                 PointsView<Ndim, TData> dev_points) const {
+  //     const auto n_seeds = seeds.size();
+  //     for (auto seed_idx : alpaka::uniformElements(acc, n_seeds)) {
+  //       internal::DeviceQueue<int, 256> local_queue;
+  //       auto idx_this_seed = seeds[seed_idx];
+  //       local_queue.push(idx_this_seed);
+  //
+  //       while (!local_queue.empty()) {
+  //         const auto follower_idx = local_queue.pop();
+  //         dev_points.cluster_index()[follower_idx] = seed_idx;
+  //
+  //         auto local_followers = followers[follower_idx];
+  //         for (auto follower : local_followers) {
+  //           local_queue.push(follower);
+  //         }
+  //       }
+  //     }
+  //   }
+  // };
 
   using WorkDiv = clue::WorkDiv<clue::Dim1D>;
 
@@ -412,12 +429,21 @@ namespace clue::detail {
   inline void assignPointsToClusters(TQueue& queue,
                                      std::size_t block_size,
                                      clue::internal::SeedArray<>& seeds,
-                                     clue::FollowersView followers,
-                                     PointsView<Ndim, TData> dev_points) {
-    const Idx grid_size = nostd::ceil_div(seeds.size(queue), block_size);
-    const auto work_division = clue::make_workdiv<TAcc>(grid_size, block_size);
-    alpaka::exec<TAcc>(
-        queue, work_division, KernelAssignClusters{}, seeds.view(), followers, dev_points);
+                                     PointsView<Ndim, TData> dev_points,
+                                     int32_t n_points) {
+    const Idx seed_grid = nostd::ceil_div(seeds.size(queue), block_size);
+    alpaka::exec<TAcc>(queue,
+                       clue::make_workdiv<TAcc>(seed_grid, block_size),
+                       KernelAssignSeedIndices{},
+                       seeds.view(),
+                       dev_points);
+
+    const Idx point_grid = nostd::ceil_div(n_points, block_size);
+    alpaka::exec<TAcc>(queue,
+                       clue::make_workdiv<TAcc>(point_grid, block_size),
+                       KernelAssignClusters{},
+                       dev_points,
+                       n_points);
   }
 
 }  // namespace clue::detail

--- a/include/CLUEstering/core/detail/ClusteringKernels.hpp
+++ b/include/CLUEstering/core/detail/ClusteringKernels.hpp
@@ -314,31 +314,6 @@ namespace clue::detail {
     }
   };
 
-  // struct OldKernelAssignClusters {
-  //   template <typename TAcc, std::size_t Ndim, std::floating_point TData>
-  //   ALPAKA_FN_ACC void operator()(const TAcc& acc,
-  //                                 clue::internal::SeedArrayView seeds,
-  //                                 clue::FollowersView followers,
-  //                                 PointsView<Ndim, TData> dev_points) const {
-  //     const auto n_seeds = seeds.size();
-  //     for (auto seed_idx : alpaka::uniformElements(acc, n_seeds)) {
-  //       internal::DeviceQueue<int, 256> local_queue;
-  //       auto idx_this_seed = seeds[seed_idx];
-  //       local_queue.push(idx_this_seed);
-  //
-  //       while (!local_queue.empty()) {
-  //         const auto follower_idx = local_queue.pop();
-  //         dev_points.cluster_index()[follower_idx] = seed_idx;
-  //
-  //         auto local_followers = followers[follower_idx];
-  //         for (auto follower : local_followers) {
-  //           local_queue.push(follower);
-  //         }
-  //       }
-  //     }
-  //   }
-  // };
-
   using WorkDiv = clue::WorkDiv<clue::Dim1D>;
 
   template <concepts::accelerator TAcc,


### PR DESCRIPTION
This PR re-desings the cluster-assigning kernel, removing the need for a fixed-size stack, thus making the kernel more general and efficient.