### PR TITLE
Use integer root to compute the number of tiles in setup_tiles

### DIFF
--- a/include/CLUEstering/core/detail/SetupTiles.hpp
+++ b/include/CLUEstering/core/detail/SetupTiles.hpp
@@ -9,12 +9,20 @@
 #include "CLUEstering/internal/nostd/ceil_div.hpp"
 #include <array>
 #include <concepts>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 
 namespace clue::detail {
+
+  /// @brief Raises base to the given exponent using only integer arithmetic.
+  constexpr int32_t integer_pow(int32_t base, std::size_t exp) {
+    int32_t result = 1;
+    for (std::size_t i = 0; i < exp; ++i) {
+      result *= base;
+    }
+    return result;
+  }
 
   template <concepts::queue TQueue,
             std::size_t Ndim,
@@ -28,8 +36,9 @@ namespace clue::detail {
                    std::size_t batch_size = 1) {
     // TODO: reconsider the way that we compute the number of tiles
     auto ntiles = nostd::ceil_div(points.size(), points_per_tile);
-    const auto n_per_dim = static_cast<int32_t>(std::ceil(std::pow(ntiles, 1. / Ndim)));
-    ntiles = static_cast<int32_t>(std::pow(n_per_dim, Ndim));
+    int32_t n_per_dim = 1;
+    while (integer_pow(n_per_dim, Ndim) < ntiles) ++n_per_dim;
+    ntiles = integer_pow(n_per_dim, Ndim);
 
     if (!tiles.has_value()) {
       tiles = std::make_optional<internal::Tiles<Ndim, std::remove_cv_t<TInput>, TDev>>(
@@ -65,8 +74,9 @@ namespace clue::detail {
                    const std::array<uint8_t, Ndim>& wrapped_coordinates,
                    std::size_t batch_size = 1) {
     auto ntiles = nostd::ceil_div(points.size(), points_per_tile);
-    const auto n_per_dim = static_cast<int32_t>(std::ceil(std::pow(ntiles, 1. / Ndim)));
-    ntiles = static_cast<int32_t>(std::pow(n_per_dim, Ndim));
+    int32_t n_per_dim = 1;
+    while (integer_pow(n_per_dim, Ndim) < ntiles) ++n_per_dim;
+    ntiles = integer_pow(n_per_dim, Ndim);
 
     if (!tiles.has_value()) {
       tiles = std::make_optional<internal::Tiles<Ndim, std::remove_cv_t<TInput>, TDev>>(


### PR DESCRIPTION
Computes the Ndim-th root of the tile count using integer arithmetic instead of std::pow / std::ceil, as suggested in #507.

The new loop increments n_per_dim until n_per_dim^Ndim >= ntiles, landing on the smallest grid that covers the requested tile count.

@sbaldu 

Closes #507 
