### PR TITLE
Migrate from pybind11 to nanobind

### DIFF
--- a/.github/workflows/benchmark-amd-gpu.yml
+++ b/.github/workflows/benchmark-amd-gpu.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         ref: ${{ inputs.head_sha }}
-        submodules: true
+        submodules: recursive
         fetch-depth: 0
 
     - name: Mark workspace as safe for git
@@ -127,7 +127,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/benchmark-nvidia-gpu.yml
+++ b/.github/workflows/benchmark-nvidia-gpu.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         ref: ${{ inputs.head_sha }}
-        submodules: true
+        submodules: recursive
         fetch-depth: 0
 
     - name: Mark workspace as safe for git
@@ -127,7 +127,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-          submodules: true
+          submodules: recursive
 
       - name: Cache apt packages
         uses: actions/cache@v6

--- a/.github/workflows/conan-example.yml
+++ b/.github/workflows/conan-example.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Cache apt packages
       uses: actions/cache@v6

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          submodules: true
+          submodules: recursive
           ref: main
 
       - name: Switch to gh-pages branch and rebase

--- a/.github/workflows/gpu-compile-check.yml
+++ b/.github/workflows/gpu-compile-check.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.36
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: recursive
 
       # ROCm's apt repo layout/supported codenames change across releases;
       # if this step starts failing, check https://rocm.docs.amd.com for the

--- a/.github/workflows/python-installation.yml
+++ b/.github/workflows/python-installation.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Install docker
         run: |

--- a/.github/workflows/python-package-anaconda.yml
+++ b/.github/workflows/python-package-anaconda.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
     - name: Set up Python 3.10
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -74,7 +74,7 @@ jobs:
 
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Export GitHub Actions cache environment variables
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Cache apt packages
       uses: actions/cache@v6

--- a/.github/workflows/test-cpp-interface.yml
+++ b/.github/workflows/test-cpp-interface.yml
@@ -93,7 +93,7 @@ jobs:
 
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Export GitHub Actions cache environment variables
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-debug-compilation.yml
+++ b/.github/workflows/test-debug-compilation.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Cache apt packages
       uses: actions/cache@v6

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
-[submodule "extern/pybind11"]
-	path = extern/pybind11
-	url = https://github.com/sbaldu/pybind11.git
-	branch = master
-  ignore = dirty
 [submodule "extern/doxygen-awesome-css"]
 	path = extern/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git
+[submodule "extern/nanobind"]
+	path = extern/nanobind
+	url = git@github.com:wjakob/nanobind.git

--- a/CLUEstering/BindingModules/CMakeLists.txt
+++ b/CLUEstering/BindingModules/CMakeLists.txt
@@ -26,10 +26,6 @@ else()
   )
 endif()
 
-# include pybind11 extern subfolder
-set(PYBIND11_FINDPYTHON ON)
-set(PYBIND11_PYTHON_VERSION ">=3.8")
-
 find_package(Boost 1.75.0 REQUIRED COMPONENTS atomic)
 
 include(FetchContent)
@@ -42,7 +38,7 @@ FetchContent_MakeAvailable(alpaka)
 file(MAKE_DIRECTORY ../lib)
 
 # Convolutional Kernels
-pybind11_add_module(CLUE_Convolutional_Kernels NO_EXTRAS SHARED
+nanobind_add_module(CLUE_Convolutional_Kernels NB_STATIC
                     ${CMAKE_CURRENT_SOURCE_DIR}/binding_kernels.cpp)
 target_include_directories(CLUE_Convolutional_Kernels
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
@@ -52,13 +48,8 @@ target_compile_definitions(
   CLUE_Convolutional_Kernels PRIVATE ALPAKA_HOST_ONLY
                                      ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
 target_precompile_headers(
-  CLUE_Convolutional_Kernels
-  PRIVATE
-  <alpaka/alpaka.hpp>
-  <pybind11/pybind11.h>
-  <pybind11/numpy.h>
-  <pybind11/stl.h>
-  <pybind11/functional.h>)
+  CLUE_Convolutional_Kernels PRIVATE <alpaka/alpaka.hpp> <nanobind/nanobind.h>
+  <nanobind/ndarray.h>)
 set_target_properties(
   CLUE_Convolutional_Kernels
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/CLUEstering/BindingModules/Run.hpp
+++ b/CLUEstering/BindingModules/Run.hpp
@@ -13,12 +13,13 @@
 #include <span>
 #include <vector>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <std::floating_point TInput, std::size_t Ndim, clue::concepts::convolutional_kernel Kernel>
 void run(TInput dc,
@@ -49,7 +50,7 @@ void run(TInput dc,
 
 namespace ALPAKA_BACKEND {
 
-  void listDevices(const std::string& backend) {
+  inline void listDevices(const std::string& backend) {
     const char tab = '\t';
     const std::vector<Device> devices = alpaka::getDevs(clue::Platform{});
     if (devices.empty()) {
@@ -70,25 +71,22 @@ namespace ALPAKA_BACKEND {
                TInput dm,
                TInput seed_dc,
                std::vector<uint8_t> wrapped,
-               py::array_t<TInput> data,
-               py::array_t<int> results,
+               nb::ndarray<TInput, nb::numpy> data,
+               nb::ndarray<int, nb::numpy> results,
                const Kernel<TInput>& kernel,
                int Ndim,
-               std::optional<py::array_t<uint32_t>> batch_sample_sizes,
+               std::optional<nb::ndarray<uint32_t, nb::numpy>> batch_sample_sizes,
                int32_t n_points,
                std::size_t device_id,
                const clue::internal::MetricDescriptor<TInput>& metric_desc) {
-    auto rData = data.request();
-    auto* pData = static_cast<TInput*>(rData.ptr);
-    auto rResults = results.request();
-    auto* pResults = static_cast<int*>(rResults.ptr);
+    auto* pData = data.data();
+    auto* pResults = results.data();
 
     std::optional<std::span<uint32_t>> batch_sample_sizes_span;
 
     if (batch_sample_sizes.has_value()) [[unlikely]] {
-      auto rBatchSizes = batch_sample_sizes->request();
-      auto* pBatchSizes = static_cast<uint32_t*>(rBatchSizes.ptr);
-      batch_sample_sizes_span = std::span<uint32_t>(pBatchSizes, rBatchSizes.size);
+      auto* pBatchSizes = batch_sample_sizes->data();
+      batch_sample_sizes_span = std::span<uint32_t>(pBatchSizes, batch_sample_sizes->size());
     } else [[likely]] {
       batch_sample_sizes_span = std::nullopt;
     }

--- a/CLUEstering/BindingModules/binding_kernels.cpp
+++ b/CLUEstering/BindingModules/binding_kernels.cpp
@@ -2,19 +2,18 @@
 #include "CLUEstering/core/ConvolutionalKernel.hpp"
 #include "MetricDescriptor.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
-PYBIND11_MODULE(CLUE_Convolutional_Kernels, m) {
+NB_MODULE(CLUE_Convolutional_Kernels, m) {
   m.doc() = "Binding of the convolutional kernels and distance metrics used in the CLUE algorithm.";
 
   // ----- Convolutional kernels -----
-  py::class_<clue::FlatKernel<float>>(m, "FlatKernel").def(py::init<float>());
-  py::class_<clue::ExponentialKernel<float>>(m, "ExponentialKernel").def(py::init<float, float>());
-  py::class_<clue::GaussianKernel<float>>(m, "GaussianKernel").def(py::init<float, float>());
+  nb::class_<clue::FlatKernel<float>>(m, "FlatKernel").def(nb::init<float>());
+  nb::class_<clue::ExponentialKernel<float>>(m, "ExponentialKernel").def(nb::init<float, float>());
+  nb::class_<clue::GaussianKernel<float>>(m, "GaussianKernel").def(nb::init<float, float>());
 
   // ----- Distance metrics -----
   // MetricDescriptor<float> is an opaque handle; users obtain instances via the
@@ -22,14 +21,14 @@ PYBIND11_MODULE(CLUE_Convolutional_Kernels, m) {
   using Descriptor = clue::internal::MetricDescriptor<float>;
   using Tag = Descriptor::Tag;
 
-  py::class_<Descriptor>(m, "MetricDescriptor");
+  nb::class_<Descriptor>(m, "MetricDescriptor");
 
   m.def(
       "EuclideanMetric",
       [](std::vector<float> weights) {
         return Descriptor{Tag::WeightedEuclidean, std::move(weights)};
       },
-      py::arg("weights") = std::vector<float>{},
+      nb::arg("weights") = std::vector<float>{},
       "Euclidean (L2) distance metric. Optionally pass one weight per coordinate dimension; "
       "omit or pass an empty list for the unweighted variant.");
 
@@ -43,7 +42,7 @@ PYBIND11_MODULE(CLUE_Convolutional_Kernels, m) {
       [](std::vector<float> weights) {
         return Descriptor{Tag::WeightedChebyshev, std::move(weights)};
       },
-      py::arg("weights") = std::vector<float>{},
+      nb::arg("weights") = std::vector<float>{},
       "Chebyshev (L-infinity) distance metric. Optionally pass one weight per coordinate "
       "dimension; omit or pass an empty list for the unweighted variant.");
 
@@ -52,7 +51,7 @@ PYBIND11_MODULE(CLUE_Convolutional_Kernels, m) {
       [](std::vector<float> periods) {
         return Descriptor{Tag::PeriodicEuclidean, std::move(periods)};
       },
-      py::arg("periods"),
+      nb::arg("periods"),
       "Periodic Euclidean metric. Pass one period per coordinate dimension; "
       "a period of 0 means the dimension is not periodic.");
 }

--- a/CLUEstering/BindingModules/cuda/CMakeLists.txt
+++ b/CLUEstering/BindingModules/cuda/CMakeLists.txt
@@ -8,20 +8,14 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
 endif()
 
 set_source_files_properties(binding_gpu_cuda.cpp PROPERTIES LANGUAGE CUDA)
-pybind11_add_module(CLUE_GPU_CUDA NO_EXTRAS SHARED binding_gpu_cuda.cpp)
+nanobind_add_module(CLUE_GPU_CUDA NB_STATIC binding_gpu_cuda.cpp)
 target_include_directories(CLUE_GPU_CUDA
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 target_link_libraries(CLUE_GPU_CUDA PRIVATE alpaka::alpaka Boost::atomic)
 target_compile_definitions(CLUE_GPU_CUDA PRIVATE ALPAKA_ACC_GPU_CUDA_ENABLED)
 target_compile_options(CLUE_GPU_CUDA PRIVATE --expt-relaxed-constexpr)
-target_precompile_headers(
-  CLUE_GPU_CUDA
-  PRIVATE
-  <alpaka/alpaka.hpp>
-  <pybind11/pybind11.h>
-  <pybind11/numpy.h>
-  <pybind11/stl.h>
-  <pybind11/functional.h>)
+target_precompile_headers(CLUE_GPU_CUDA PRIVATE <alpaka/alpaka.hpp>
+                          <nanobind/nanobind.h> <nanobind/ndarray.h>)
 set_target_properties(
   CLUE_GPU_CUDA
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
+++ b/CLUEstering/BindingModules/cuda/binding_gpu_cuda.cpp
@@ -8,16 +8,11 @@
 
 #include "../Run.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
 
 namespace alpaka_cuda_async {
 
-  PYBIND11_MODULE(CLUE_GPU_CUDA, m) {
+  NB_MODULE(CLUE_GPU_CUDA, m) {
     m.doc() = "Binding of the CLUE algorithm running on CUDA GPUs";
 
     m.def("listDevices",

--- a/CLUEstering/BindingModules/hip/CMakeLists.txt
+++ b/CLUEstering/BindingModules/hip/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(hip)
 
 set(hip_BASE "${hip_INCLUDE_DIRS}/..")
 set(CMAKE_CXX_COMPILER "${hip_BASE}/bin/hipcc")
-pybind11_add_module(CLUE_GPU_HIP NO_EXTRAS SHARED binding_gpu_hip.cpp)
+nanobind_add_module(CLUE_GPU_HIP NB_STATIC binding_gpu_hip.cpp)
 target_include_directories(CLUE_GPU_HIP
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 target_link_libraries(CLUE_GPU_HIP PRIVATE alpaka::alpaka Boost::atomic)

--- a/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
+++ b/CLUEstering/BindingModules/hip/binding_gpu_hip.cpp
@@ -8,16 +8,11 @@
 
 #include "../Run.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
 
 namespace alpaka_rocm_async {
 
-  PYBIND11_MODULE(CLUE_GPU_HIP, m) {
+  NB_MODULE(CLUE_GPU_HIP, m) {
     m.doc() = "Binding of the CLUE algorithm running on AMD GPUs";
 
     m.def("listDevices",

--- a/CLUEstering/BindingModules/openmp/CMakeLists.txt
+++ b/CLUEstering/BindingModules/openmp/CMakeLists.txt
@@ -1,4 +1,4 @@
-pybind11_add_module(CLUE_CPU_OMP NO_EXTRAS SHARED binding_cpu_omp.cpp)
+nanobind_add_module(CLUE_CPU_OMP NB_STATIC binding_cpu_omp.cpp)
 target_include_directories(CLUE_CPU_OMP
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 target_link_libraries(CLUE_CPU_OMP PRIVATE alpaka::alpaka Boost::atomic)
@@ -6,14 +6,7 @@ target_compile_definitions(
   CLUE_CPU_OMP PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
 target_link_libraries(CLUE_CPU_OMP PRIVATE OpenMP::OpenMP_CXX)
 target_compile_options(CLUE_CPU_OMP PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
-target_precompile_headers(
-  CLUE_CPU_OMP
-  PRIVATE
-  <alpaka/alpaka.hpp>
-  <pybind11/pybind11.h>
-  <pybind11/numpy.h>
-  <pybind11/stl.h>
-  <pybind11/functional.h>)
+target_precompile_headers(CLUE_CPU_OMP REUSE_FROM CLUE_Convolutional_Kernels)
 set_target_properties(
   CLUE_CPU_OMP
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
+++ b/CLUEstering/BindingModules/openmp/binding_cpu_omp.cpp
@@ -8,16 +8,11 @@
 
 #include "../Run.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
 
 namespace alpaka_omp2_async {
 
-  PYBIND11_MODULE(CLUE_CPU_OMP, m) {
+  NB_MODULE(CLUE_CPU_OMP, m) {
     m.doc() = "Binding of the CLUE algorithm running on CPU with OpenMP";
 
     m.def("listDevices",

--- a/CLUEstering/BindingModules/serial/CMakeLists.txt
+++ b/CLUEstering/BindingModules/serial/CMakeLists.txt
@@ -1,4 +1,4 @@
-pybind11_add_module(CLUE_CPU_Serial NO_EXTRAS SHARED binding_cpu.cpp)
+nanobind_add_module(CLUE_CPU_Serial NB_STATIC binding_cpu.cpp)
 target_include_directories(CLUE_CPU_Serial
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 target_link_libraries(CLUE_CPU_Serial PRIVATE alpaka::alpaka Boost::atomic)

--- a/CLUEstering/BindingModules/serial/binding_cpu.cpp
+++ b/CLUEstering/BindingModules/serial/binding_cpu.cpp
@@ -8,16 +8,11 @@
 
 #include "../Run.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
 
 namespace alpaka_serial_sync {
 
-  PYBIND11_MODULE(CLUE_CPU_Serial, m) {
+  NB_MODULE(CLUE_CPU_Serial, m) {
     m.doc() = "Binding of the CLUE algorithm running serially on CPU";
 
     m.def("listDevices",

--- a/CLUEstering/BindingModules/tbb/CMakeLists.txt
+++ b/CLUEstering/BindingModules/tbb/CMakeLists.txt
@@ -1,18 +1,11 @@
-pybind11_add_module(CLUE_CPU_TBB NO_EXTRAS SHARED binding_cpu_tbb.cpp)
+nanobind_add_module(CLUE_CPU_TBB NB_STATIC binding_cpu_tbb.cpp)
 target_include_directories(CLUE_CPU_TBB
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 target_compile_definitions(
   CLUE_CPU_TBB PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
 target_link_libraries(CLUE_CPU_TBB PRIVATE alpaka::alpaka Boost::atomic
                                            TBB::tbb)
-target_precompile_headers(
-  CLUE_CPU_TBB
-  PRIVATE
-  <alpaka/alpaka.hpp>
-  <pybind11/pybind11.h>
-  <pybind11/numpy.h>
-  <pybind11/stl.h>
-  <pybind11/functional.h>)
+target_precompile_headers(CLUE_CPU_TBB REUSE_FROM CLUE_Convolutional_Kernels)
 set_target_properties(
   CLUE_CPU_TBB
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
+++ b/CLUEstering/BindingModules/tbb/binding_cpu_tbb.cpp
@@ -8,16 +8,11 @@
 
 #include "../Run.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
 
 namespace alpaka_tbb_async {
 
-  PYBIND11_MODULE(CLUE_CPU_TBB, m) {
+  NB_MODULE(CLUE_CPU_TBB, m) {
     m.doc() = "Binding of the CLUE algorithm running on CPU with TBB";
 
     m.def("listDevices",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ project(
 option(BUILD_PYTHON "Build the Python bindings" OFF)
 
 if(BUILD_PYTHON)
-  add_subdirectory(extern/pybind11)
+  find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development.Module)
+  add_subdirectory(extern/nanobind EXCLUDE_FROM_ALL)
   add_subdirectory(CLUEstering/BindingModules)
 endif()
 


### PR DESCRIPTION
The compilation with nanobind gets approximately 2x faster and the resulting executables are 2-3x smaller